### PR TITLE
Fix inkscape command line invocation on Mac OS X

### DIFF
--- a/renderlib.py
+++ b/renderlib.py
@@ -129,7 +129,7 @@ def rendertask(task):
 			fp.write( etree.tostring(svg, encoding='unicode') )
 
 		# invoke inkscape to convert the generated svg-file into a png inside the .frames-directory
-		errorReturn = subprocess.check_output('cd {0} && inkscape --export-background=white --export-png=.frames/{1:04d}.png .gen.svg 2>&1 >/dev/null'.format(task.workdir, frameNr), shell=True, universal_newlines=True)
+		errorReturn = subprocess.check_output('cd {0} && inkscape --export-background=white --export-png=.frames/{1:04d}.png .gen.svg >/dev/null 2>&1'.format(task.workdir, frameNr), shell=True, universal_newlines=True)
 		if errorReturn != '':
 			print("inkscape exitted with error\n"+errorReturn)
 			sys.exit(42)


### PR DESCRIPTION
Die Inkscape Binary (Homebrew) auf Mac OS X wirft ab Mac OS 10.9 ein Warning, der anscheinend nur unterdrückt wird, wenn man "2>&1" ans Ende des Aufrufs stellt.