### PR TITLE
add intro/outro for osmodevcon 2019

### DIFF
--- a/osmodevcon2019/__init__.py
+++ b/osmodevcon2019/__init__.py
@@ -1,0 +1,147 @@
+#!/usr/bin/python3
+
+from renderlib import *
+from easing import *
+
+# URL to Schedule-XML
+scheduleUrl = 'https://pretalx.sysmocom.de/osmodevcon2019/schedule/export/schedule.xml'
+
+def introFrames(args):
+    #fade in title
+    frames = 3*fps
+    for i in range(0, frames):
+        yield(
+            ('title', 'style', 'opacity', easeInQuad(i, 0, 1, frames)),
+        )
+    # fade in subtitle and names
+    frames = 1*fps
+    for i in range(0, frames):
+        yield(
+            ('title', 'style', 'opacity', 1),
+            ('subtitle',    'style', 'opacity', easeInQuad(i, 0, 1, frames)),
+            ('personnames', 'style', 'opacity', easeInQuad(i, 0, 1, frames)),
+        )
+    #show whole image for 2 seconds
+    frames = 2*fps
+    for i in range(0, frames):
+        yield(
+            ('title', 'style', 'opacity', 1),
+            ('personnames', 'style', 'opacity', 1),
+            ('subtitle', 'style', 'opacity', 1),
+        )
+
+def backgroundFrames(parameters):
+    frames = 5*fps
+    for i in range(0, frames):
+        yield(
+            ('logo', 'style', 'opacity', 1),
+        )
+
+def outroFrames(args):
+    frames = 2*fps
+    for i in range(0, frames):
+        yield(
+            ('logo',    'style', 'opacity', 1),
+            ('sublogo', 'style', 'opacity', 1),
+            ('cclogo',  'style', 'opacity', 1),
+        )
+    # fade out
+    frames = 3*fps
+    for i in range(0, frames):
+        yield(
+            ('logo',     'style', 'opacity', "%.4f" % easeInCubic(i, 1, -1, frames)),
+            ('sublogo',  'style', 'opacity', "%.4f" % easeInCubic(i, 1, -1, frames)),
+            ('cclogo',   'style', 'opacity', "%.4f" % easeInCubic(i, 1, -1, frames)),
+        )
+
+def pauseFrames(args):
+    #fade in pause
+    frames = 4*fps
+    for i in range(0, frames):
+        yield(
+            ('pause',  'style', 'opacity', "%.4f" % easeInCubic(i, 0.2, 1, frames)),
+        )
+
+    # fade out
+    frames = 4*fps
+    for i in range(0, frames):
+        yield(
+            ('pause',  'style', 'opacity', "%.4f" % easeInCubic(i, 1, -0.8, frames)),
+        )
+
+def debug():
+    render('intro.svg',
+        '../intro.ts',
+        introFrames,
+        {
+            '$id': 7776,
+            '$title': 'Configuring + running GPRS/EDGE data services with OsmoPCU, OsmoSGSN and OpenGGSN',
+            '$subtitle': 'With some subtitle!',
+            '$personnames':  'Alexander Chemeris + Harald Welte'
+        }
+    )
+
+    render('outro.svg',
+        '../outro.ts',
+        outroFrames
+    )
+
+    render(
+        'background.svg',
+        '../background.ts',
+        backgroundFrames
+    )
+
+    render('pause.svg',
+        '../pause.ts',
+        pauseFrames
+    )
+
+
+def tasks(queue, args, idlist, skiplist):
+    # iterate over all events extracted from the schedule xml-export
+    for event in events(scheduleUrl):
+        if not (idlist==[]):
+                if 000000 in idlist:
+                        print("skipping id (%s [%s])" % (event['title'], event['id']))
+                        continue
+                if int(event['id']) not in idlist:
+                        print("skipping id (%s [%s])" % (event['title'], event['id']))
+                        continue
+
+        # generate a task description and put them into the queue
+        queue.put(Rendertask(
+            infile = 'intro.svg',
+            outfile = str(event['id'])+".ts",
+            sequence = introFrames,
+            parameters = {
+                '$id': event['id'],
+                '$title': event['title'],
+                '$subtitle': event['subtitle'],
+                '$personnames': event['personnames']
+            }
+        ))
+
+    # place a task for the outro into the queue
+    if not "out" in skiplist:
+        queue.put(Rendertask(
+            infile = 'outro.svg',
+            outfile = 'outro.ts',
+            sequence = outroFrames
+         ))
+
+    # place the pause-sequence into the queue
+    if not "pause" in skiplist:
+        queue.put(Rendertask(
+            infile = 'pause.svg',
+            outfile = 'pause.ts',
+            sequence = pauseFrames
+        ))
+
+    # place the background-sequence into the queue
+    if not "bg" in skiplist:
+        queue.put(Rendertask(
+            infile = 'background.svg',
+            outfile = 'background.ts',
+            sequence = backgroundFrames
+        ))

--- a/osmodevcon2019/artwork/background.svg
+++ b/osmodevcon2019/artwork/background.svg
@@ -1,0 +1,946 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="508mm"
+   height="285.74997mm"
+   viewBox="0 0 1800 1012.4999"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"
+   sodipodi:docname="background.svg"
+   inkscape:export-filename="background.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3374-5-7-7-0">
+      <stop
+         id="stop3376-8-6-4-2"
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3378-6-7-4-9"
+         style="stop-color:#729fcf;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3362-8-6-0-9">
+      <stop
+         id="stop3364-4-5-78-9"
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3366-7-6-6-4"
+         style="stop-color:#3465a4;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.837126"
+       y1="44.528019"
+       x2="21.036427"
+       y2="21.041553"
+       id="linearGradient3991-3-88-5"
+       xlink:href="#linearGradient7101-4-9-4-1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient7101-4-9-4-1">
+      <stop
+         id="stop7103-0-4-31-0"
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7105-6-8-4-3"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="39.06765"
+       y1="28.5"
+       x2="39.421204"
+       y2="10.934953"
+       id="linearGradient3993-1-9-7"
+       xlink:href="#linearGradient6979-9-2-2-8"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient6979-9-2-2-8">
+      <stop
+         id="stop6981-9-9-0-8"
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6983-0-3-6-6"
+         style="stop-color:#555753;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <linearGradient
+       id="linearGradient7131-6-1-5-7">
+      <stop
+         id="stop7133-4-5-2-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7135-6-9-5-0"
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <linearGradient
+       id="linearGradient7153-0-1-9-75">
+      <stop
+         id="stop7155-8-7-3-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7157-5-7-7-7"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.837126"
+       y1="44.528019"
+       x2="21.036427"
+       y2="21.041553"
+       id="linearGradient3991-3-88-5-3"
+       xlink:href="#linearGradient7101-4-9-4-1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="39.06765"
+       y1="28.5"
+       x2="39.421204"
+       y2="10.934953"
+       id="linearGradient3993-1-9-7-2"
+       xlink:href="#linearGradient6979-9-2-2-8"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <linearGradient
+       x1="24.837126"
+       y1="44.528019"
+       x2="21.036427"
+       y2="21.041553"
+       id="linearGradient3991-3-88-5-3-4"
+       xlink:href="#linearGradient7101-4-9-4-1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="39.06765"
+       y1="28.5"
+       x2="39.421204"
+       y2="10.934953"
+       id="linearGradient3993-1-9-7-2-4"
+       xlink:href="#linearGradient6979-9-2-2-8"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-3"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-1"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-7"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-6"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-4"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-7"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-4"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-0"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       r="4.5250292"
+       fy="8.0709476"
+       fx="10.28125"
+       cy="8.0709476"
+       cx="10.28125"
+       gradientTransform="matrix(4.9499444,0,0,4.9510321,-11.38809,35.312197)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3637-3"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       inkscape:collect="always" />
+    <radialGradient
+       r="4.5250292"
+       fy="9.8424416"
+       fx="10.28125"
+       cy="9.8424416"
+       cx="10.28125"
+       gradientTransform="matrix(23.169932,0,0,7.6402677,-198.71238,8.843597)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3639-5"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       inkscape:collect="always" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9-7"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1-5"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2-9"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9-8"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-9"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-1"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-2"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-9"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.49497476"
+     inkscape:cx="-330.66755"
+     inkscape:cy="386.73989"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     units="mm"
+     inkscape:window-width="956"
+     inkscape:window-height="1041"
+     inkscape:window-x="960"
+     inkscape:window-y="37"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:measure-start="63.3968,-113.628"
+     inkscape:measure-end="34.3452,-129.3"
+     inkscape:snap-page="true"
+     inkscape:pagecheckerboard="true"
+     gridtolerance="5"
+     objecttolerance="10"
+     guidetolerance="10"
+     inkscape:lockguides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid20483"
+       originx="0"
+       originy="-0.00012144696" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     transform="translate(0,-67.5)"
+     style="display:inline">
+    <rect
+       style="opacity:1;fill:#1a1a1a;fill-opacity:1;stroke:none;stroke-width:1.00031257;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect20497"
+       width="1800"
+       height="1012.4999"
+       x="0"
+       y="67.5"
+       inkscape:label="bg color" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Text"
+     style="display:inline"
+     transform="translate(0,-67.5)">
+    <flowRoot
+       xml:space="preserve"
+       id="title"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;opacity:0;fill:#555555;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       transform="matrix(0.9375,0,0,0.9375,596.82417,403.33401)"
+       inkscape:label="title"
+       inkscape:transform-center-x="4.0178571"
+       inkscape:transform-center-y="-24.107143"><flowRegion
+         id="flowRegion20435"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1"><rect
+           id="rect20437"
+           width="604.28571"
+           height="189.99998"
+           x="61.42857"
+           y="67.714287"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1" /></flowRegion><flowPara
+         id="flowPara24792"
+         style="font-size:192px">Pause</flowPara></flowRoot>    <flowRoot
+       xml:space="preserve"
+       id="flowRoot25337"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"><flowRegion
+         id="flowRegion25339"><rect
+           id="rect25341"
+           width="14.285714"
+           height="90"
+           x="902.85712"
+           y="472.85715" /></flowRegion><flowPara
+         id="flowPara25343" /></flowRoot>    <flowRoot
+       inkscape:transform-center-y="-24.107143"
+       inkscape:transform-center-x="4.0178571"
+       inkscape:label="title"
+       transform="matrix(0.9375,0,0,0.9375,604.85988,449.04839)"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;opacity:0;fill:#555555;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="pause"
+       xml:space="preserve"><flowRegion
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1"
+         id="flowRegion25395"><rect
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1"
+           y="67.714287"
+           x="61.42857"
+           height="189.99998"
+           width="604.28571"
+           id="rect25393" /></flowRegion><flowPara
+         style="font-size:192px"
+         id="flowPara25397">Pause</flowPara></flowRoot>    <g
+       id="g441"
+       transform="matrix(0.84639363,0,0,0.84639363,37.064912,38.785126)">
+      <text
+         id="text3760-7"
+         y="243.6349"
+         x="277.56836"
+         style="font-style:normal;font-weight:normal;font-size:81.56085968px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.03902125"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:130.49736023px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';fill:#a00000;fill-opacity:1;stroke-width:2.03902125"
+           y="243.6349"
+           x="277.56836"
+           id="tspan3762-0"
+           sodipodi:role="line">o</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path3959-9-26-3"
+         d="m 221.54901,178.00783 -8.8372,15.20901 -4.0423,-6.95739 1.1988,54.79873 c 3.8707,-2.70354 5.2943,1.46986 5.3524,-0.6173 l 1.4178,-50.79232 c 3.0015,-1.56596 6.002,-2.21826 8.8729,-2.21826 5.22,0 7.2929,1.82538 7.4234,6.52328 l 0.5775,46.96519 c 3.6204,-1.02991 6.8905,0.79083 6.9055,-0.35065 l 0.6452,-48.85683 c 2.8709,-1.82699 7.1579,-4.15375 10.1592,-4.15375 5.22,0 6.2837,2.61406 6.3918,8.87693 l 0.7847,45.42003 c 2.4547,-0.3861 5.9417,1.23813 5.9736,-0.39459 l 0.9002,-45.80627 c 0.2308,-11.74253 1.3452,-17.49097 -11.7046,-17.49097 -5.3503,0 -11.6124,1.56672 -16.0494,4.04615 -2.4795,-2.60972 -6.1326,-4.04615 -11.7441,-4.04615 -1.5299,0 -2.9125,-0.0694 -4.2254,-0.15573 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:64px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Andale Mono';writing-mode:lr-tb;display:inline;fill:#a00000;fill-opacity:1;stroke:#a00000;stroke-width:2.03902125;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#e19c9c;stroke-width:10.19510746;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3981-0-4-1"
+         d="m 212.71081,193.21678 -9.1897,-15.80983 -9.1896,-15.80995 h 18.3793 18.3792 l -9.1896,15.80995 z" />
+      <path
+         inkscape:connector-curvature="0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:10.24006462;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3983-4-9-2"
+         d="M 261.34211,239.81102 V 183.28218" />
+      <path
+         inkscape:connector-curvature="0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:10.19510746;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3985-4-0-9"
+         d="M 236.92411,239.78722 V 199.37075" />
+      <path
+         inkscape:connector-curvature="0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:9.52051163;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3951-0-4-91-2"
+         d="m 212.70941,240.14133 -0.022,-23.96402" />
+      <g
+         id="text5473"
+         style="font-style:normal;font-weight:normal;font-size:16.93333244px;line-height:125%;font-family:Sans;letter-spacing:0.03704167px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         transform="matrix(7.7065378,0,0,7.7065378,-370.09593,-1045.102)"
+         aria-label="Os">
+        <path
+           inkscape:connector-curvature="0"
+           id="path5483"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.93333244px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';letter-spacing:0.03704167px;fill:#a00000;fill-opacity:1;stroke-width:0.26458332"
+           d="m 60.829899,161.23206 c 0,4.8768 0.8636,6.1468 3.048,6.1468 2.2352,0 3.2004,-1.54094 3.2004,-6.1976 0,-4.572 -0.8128,-5.96054 -3.014133,-5.96054 -2.1844,0 -3.234267,1.50707 -3.234267,6.01134 z m 1.540934,0.33866 c 0,-3.6576 0.474133,-4.94453 1.659466,-4.94453 1.2192,0 1.557867,1.20227 1.557867,4.58893 0,3.4544 -0.423334,4.75827 -1.642533,4.75827 -1.202267,0 -1.5748,-1.25307 -1.5748,-4.40267 z" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path5485"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.93333244px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';letter-spacing:0.03704167px;fill:#a00000;fill-opacity:1;stroke-width:0.26458332"
+           d="m 70.886976,158.59046 c -1.896533,0 -2.760133,0.8128 -2.760133,1.99813 0,0.5588 0.2032,1.1684 0.9652,1.79493 l 1.642533,1.40547 c 0.508,0.4572 0.677333,0.8636 0.677333,1.3208 0,0.67733 -0.508,1.04987 -1.371599,1.04987 -0.6604,0 -1.202267,-0.13547 -1.693334,-0.42334 -0.186266,0.3048 -0.237066,0.59267 -0.237066,0.79587 0,0.59267 0.8636,0.8636 2.065866,0.8636 1.7272,0 2.794,-0.84667 2.794,-2.35373 0,-0.84667 -0.270933,-1.40547 -0.999067,-2.11667 l -1.5748,-1.27 c -0.575733,-0.47413 -0.677333,-0.74507 -0.677333,-1.04987 0,-0.52493 0.541867,-0.8128 1.337733,-0.8128 0.643467,0 1.151467,0.13547 1.659467,0.44027 0.186267,-0.2032 0.3048,-0.47413 0.3048,-0.69427 0,-0.33866 -0.389467,-0.94826 -2.1336,-0.94826 z" />
+      </g>
+    </g>
+    <g
+       aria-label="DevCon"
+       transform="matrix(6.5227642,0,0,6.5227642,-489.80588,-735.6063)"
+       style="font-style:normal;font-weight:bold;font-size:16.93333244px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Yanone Kaffeesatz Bold';letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5477">
+      <path
+         d="m 91.538186,154.66105 c -0.372533,0 -0.474133,0.11853 -0.474133,0.33867 v 11.51466 h 2.1844 c 2.286,0 3.234267,-1.99813 3.234267,-6.51933 0,-4.35187 -1.0668,-5.334 -3.318934,-5.334 z m 2.760134,5.1308 c 0,4.30107 -0.474134,4.9276 -0.999067,4.9276 h -0.338667 v -8.3312 h 0.321734 c 0.6096,0 1.016,0.37253 1.016,3.4036 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.93333244px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:0.26458332"
+         id="path5488"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 100.15963,157.87838 c -1.591729,0 -2.980262,0.7112 -2.980262,4.80907 0,3.21733 1.083733,3.99627 2.624666,3.99627 1.320796,0 2.404536,-0.37254 2.404536,-1.04987 0,-0.38947 -0.0508,-0.93133 -0.1524,-1.27 -0.59267,0.28787 -1.18534,0.47413 -1.79494,0.47413 -0.812796,0 -1.049863,-0.47413 -1.100663,-1.54093 0.829734,-0.0169 2.099733,-0.0847 2.929463,-0.254 0.16934,-0.6604 0.23707,-1.59173 0.23707,-2.40453 0,-1.96427 -0.8128,-2.76014 -2.16747,-2.76014 z m -0.253996,1.64254 c 0.423336,0 0.575736,0.16933 0.575736,1.25306 0,0.27094 -0.0169,0.67734 -0.0847,0.88054 -0.254,0.11853 -0.778933,0.1524 -1.253066,0.1524 0.0508,-1.54094 0.237067,-2.286 0.762,-2.286 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.93333244px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:0.26458332"
+         id="path5490"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 104.26941,165.75238 c 0.1016,0.47414 0.3048,0.84667 0.79586,0.84667 0.3556,0 0.98214,-0.0169 1.3716,-0.0847 l 1.69334,-8.46666 c -1.94734,0 -1.94734,0 -1.99814,0.37253 l -0.23706,2.06587 c -0.16934,1.45626 -0.32174,4.04706 -0.32174,4.04706 h -0.0339 c 0,0 -0.1524,-2.5908 -0.33867,-4.04706 l -0.3048,-2.4384 c -2.16747,0 -2.1844,0 -2.06587,0.5588 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.93333244px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:0.26458332"
+         id="path5492"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 112.00926,154.40705 c -1.524,0 -3.38666,1.016 -3.38666,6.57013 0,4.74134 0.9144,5.7912 2.82786,5.7912 1.28694,0 2.06587,-0.4572 2.06587,-1.25306 0,-0.4064 -0.11853,-0.82974 -0.254,-1.1176 -0.32173,0.16933 -0.79587,0.254 -1.3208,0.254 -0.94827,0 -1.3208,-0.88054 -1.3208,-3.82694 0,-3.69146 0.88053,-4.572 1.84573,-4.572 0.37254,0 0.67734,0.13547 0.88054,0.28787 0.13546,-0.28787 0.27093,-0.67733 0.27093,-1.13453 0,-0.508 -0.16933,-0.99907 -1.60867,-0.99907 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.93333244px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:0.26458332"
+         id="path5494"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 113.8288,162.26412 c 0,3.79306 0.84667,4.4196 2.67547,4.4196 1.8288,0 2.77707,-1.2192 2.77707,-4.48734 0,-3.42053 -0.82974,-4.318 -2.6416,-4.318 -1.79494,0 -2.81094,1.3208 -2.81094,4.38574 z m 2.0828,-0.0169 c 0,-2.40453 0.28787,-2.7432 0.6604,-2.7432 0.49107,0 0.62654,0.3048 0.62654,2.7432 0,2.60774 -0.32174,2.86174 -0.64347,2.86174 -0.42333,0 -0.64347,-0.22014 -0.64347,-2.86174 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.93333244px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:0.26458332"
+         id="path5496"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 120.08673,166.51438 c 1.86266,0 1.89653,0 1.89653,-0.33866 v -6.46854 c 0.18627,-0.13546 0.42333,-0.2032 0.64347,-0.2032 0.47413,0 0.5588,0.27094 0.5588,1.15147 v 5.85893 c 1.91346,0 1.96426,0 1.96426,-0.33866 v -6.11294 c 0,-1.69333 -0.72813,-2.1844 -2.4384,-2.1844 -0.84666,0 -2.09973,0.3048 -2.62466,0.5588 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.93333244px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:0.26458332"
+         id="path5498"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="2019"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:135.91038513px;line-height:101.93280029px;font-family:Galette;-inkscape-font-specification:'Galette Bold';letter-spacing:0px;word-spacing:0px;fill:#3566a5;fill-opacity:1;stroke:none;stroke-width:4.07731199px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="text1093"
+       transform="matrix(0.84639363,0,0,0.84639363,-1098.677,81.683415)">
+      <path
+         d="m 1450.8965,383.02967 c 4.6209,-2.44639 13.4551,-4.07731 17.8042,-4.07731 4.8928,0 8.0188,2.58229 8.0188,7.20325 0,11.28056 -15.3579,23.51249 -26.7744,43.49132 -2.99,5.30051 -3.5337,7.20325 -3.5337,12.09602 0,0.40774 0,2.5823 0.5437,4.21323 h 44.8504 c 3.3978,0 3.5337,-3.12594 3.5337,-15.76561 0,0 -7.3392,1.49502 -18.6197,1.49502 h -10.0574 c 12.5037,-20.25065 27.5898,-31.80303 27.5898,-48.11228 0,-12.36785 -5.4364,-19.16336 -20.7943,-19.16336 -12.2319,0 -24.4639,3.39776 -24.4639,7.61098 0,2.31047 0.136,7.20325 1.9028,11.14465 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#3566a5;fill-opacity:1;stroke-width:4.07731199px"
+         id="path1095"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 1500.8287,405.7267 c 0,25.82298 4.2132,41.45267 24.0561,41.45267 19.5711,0 24.8716,-15.49378 24.8716,-46.48135 0,-23.78432 -7.2032,-36.28807 -24.5998,-36.28807 -17.1247,0 -24.3279,14.13468 -24.3279,41.31675 z m 16.5811,0.54364 c 0,-17.39652 1.2231,-28.54118 8.5623,-28.54118 6.2519,0 7.7469,8.42645 7.7469,22.96886 0,24.46387 -2.7182,32.89031 -8.2905,32.89031 -7.0674,0 -8.0187,-6.79552 -8.0187,-27.31799 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#3566a5;fill-opacity:1;stroke-width:4.07731199px"
+         id="path1097"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 1560.6823,381.53465 c 0,0 5.8442,-1.3591 12.9115,-1.63092 l -1.2232,51.78186 c -12.6396,0 -17.2606,0.81546 -17.2606,4.21322 0,3.53367 0.1359,6.65961 0.4078,10.05737 h 45.2581 c 3.3978,0 3.3978,-3.26185 3.3978,-14.81424 0,0 -4.0773,0.54365 -8.2906,0.54365 h -7.6109 l 1.6309,-66.46018 c -0.6796,-0.54364 -2.7182,-0.81546 -3.9414,-0.81546 -7.2033,0 -27.5898,4.62095 -27.5898,7.74689 0,3.66958 0.6795,6.5237 2.3104,9.37781 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#3566a5;fill-opacity:1;stroke-width:4.07731199px"
+         id="path1099"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 1622.7106,445.68436 c -3.3978,0 -6.9314,-0.67956 -9.6497,-1.49502 -0.8154,2.85412 -1.3591,7.47507 -1.3591,10.05737 0,4.48504 5.7083,5.84415 13.0474,5.84415 24.1921,0 33.434,-17.39653 33.8417,-53.27687 -0.6795,-34.79306 -4.0773,-43.62724 -23.6484,-43.62724 -16.3092,0 -25.5511,10.05737 -25.5511,33.9776 0,17.39653 7.6109,27.86163 18.4838,27.86163 7.7469,0 12.096,-2.31048 15.7656,-6.93143 -0.9514,14.95014 -5.0287,27.58981 -20.9302,27.58981 z m 9.9214,-34.65715 c -5.5723,0 -8.2905,-6.11597 -8.2905,-15.49379 0,-12.77557 4.621,-18.89154 10.8728,-18.89154 6.9315,0 8.8342,6.38779 8.8342,27.31799 v 0.81546 c -3.6696,4.75686 -7.4751,6.25188 -11.4165,6.25188 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#3566a5;fill-opacity:1;stroke-width:4.07731199px"
+         id="path1101"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="title"
+     style="display:none">
+    <g
+       style="display:inline"
+       id="g3732-6"
+       transform="matrix(2.0475567,0,0,2.0475567,979.07911,-71.674635)">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 60.69548,67.493897 c 0,11.5675 -9.48796,20.9448 -21.19195,20.9448 -11.703989,0 -21.191949,-9.3773 -21.191949,-20.9448 0,-11.5674 9.48796,-20.9447 21.191949,-20.9447 11.70399,0 21.19195,9.3773 21.19195,20.9447 z"
+         id="path3544-1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;opacity:0.8;fill:url(#radialGradient3637-3);fill-opacity:1;stroke:url(#radialGradient3639-5);stroke-width:1.46151388;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+      <g
+         transform="matrix(1.4615138,0,0,2.5218672,4.4272,31.547917)"
+         id="g3546-8"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:#000000;fill-opacity:1;stroke:none">
+        <path
+           inkscape:connector-curvature="0"
+           d="m 24,13 -8.1875,15.225744 c 11.445471,0 5.976697,0 16.34375,0 z m 0,4.96875 4,7.421875 h -7.953125 z"
+           id="path3548-79"
+           style="fill:url(#linearGradient3991-3-88-5);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3993-1-9-7);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 26.355979,42.522608 20,21.277828 13.644021,42.522609"
+           transform="matrix(1,0,0,0.57953638,4,2.7937247)"
+           id="path3550-2"
+           style="fill:none;stroke:#ffffff;stroke-width:1.31358945px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <path
+         inkscape:connector-curvature="0"
+         d="m 53.38791,67.493897 c 0,7.6681 -6.21625,13.8844 -13.88438,13.8844 -7.66813,0 -13.884379,-6.2163 -13.884379,-13.8844 0,-7.6681 6.216249,-13.8844 13.884379,-13.8844 7.66813,0 13.88438,6.2163 13.88438,13.8844 z"
+         id="path3552-0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:url(#radialGradient3995-7-4-0-2-2-0-9);fill-opacity:1;stroke:url(#radialGradient3997-3-3-4-7-7-6-1);stroke-width:1.46151388;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+      <g
+         transform="matrix(3.2735609,0,0,3.2593101,-24.33091,59.292917)"
+         id="g3554-2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:#000000;fill-opacity:1;stroke:none">
+        <path
+           inkscape:connector-curvature="0"
+           d="M 11,2.25 C 11,3.2164983 10.195512,4 9.203125,4 8.2107383,4 7.40625,3.2164983 7.40625,2.25 7.40625,1.2835017 8.2107383,0.5 9.203125,0.5 10.195512,0.5 11,1.2835017 11,2.25 Z"
+           transform="matrix(1.1130433,0,0,1.1428572,9.2565233,-0.07142864)"
+           id="path3556-3"
+           style="fill:url(#radialGradient3999-1-4-6-0-0-3-2);fill-opacity:1;stroke:#555753;stroke-width:0.39671427;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 20,1.5 C 20,1.7761424 19.776142,2 19.5,2 19.223858,2 19,1.7761424 19,1.5 19,1.2238576 19.223858,1 19.5,1 19.776142,1 20,1.2238576 20,1.5 Z"
+           transform="matrix(1.8125,0,0,1.8125,-16.465404,-0.9288198)"
+           id="path3558-7"
+           style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      </g>
+      <path
+         inkscape:connector-curvature="0"
+         d="m 44.61882,67.441097 c 0,2.8124 -2.2902,5.0924 -5.1153,5.0924 -2.8251,0 -5.1153,-2.28 -5.1153,-5.0924 0,-2.8125 2.2902,-5.0924 5.1153,-5.0924 2.8251,0 5.1153,2.2799 5.1153,5.0924 z"
+         id="path3560-5"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:url(#radialGradient4001-9-6-9-6-60-6-9);stroke-width:1.46151364;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:131.04367065px;line-height:125%;font-family:Sans;letter-spacing:0.28665793px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+       x="1104.8673"
+       y="136.28465"
+       id="text3743-6-9"><tspan
+         sodipodi:role="line"
+         id="tspan3745-0-2"
+         x="1104.8673"
+         y="136.28465"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';letter-spacing:0.28665793px;fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+         dx="0 0">Os</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:81.90226746px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+       x="1288.4238"
+       y="136.28465"
+       id="text3760-7-2"><tspan
+         sodipodi:role="line"
+         id="tspan3762-0-8"
+         x="1288.4238"
+         y="136.28465"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';fill:#a00000;fill-opacity:1;stroke-width:2.04755735">o</tspan></text>
+    <text
+       id="text4707-97"
+       y="137.59502"
+       x="1338.8434"
+       style="font-style:normal;font-weight:bold;font-size:131.04367065px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Yanone Kaffeesatz Bold';letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+         y="137.59502"
+         x="1338.8434"
+         id="tspan4705-36"
+         sodipodi:role="line">Con</tspan></text>
+    <path
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:64px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Andale Mono';writing-mode:lr-tb;display:inline;fill:#a00000;fill-opacity:1;stroke:#a00000;stroke-width:2.04755735;stroke-opacity:1"
+       d="m 1232.1703,70.382814 -8.8741,15.272702 -4.0593,-6.9865 1.2039,55.028084 c 3.887,-2.71488 5.3164,1.47605 5.3748,-0.61985 l 1.4237,-51.004974 c 3.0141,-1.57252 6.0272,-2.227521 8.9101,-2.227521 5.2418,0 7.3232,1.833021 7.4545,6.550591 l 0.5798,47.161764 c 3.6356,-1.03422 6.9193,0.79411 6.9344,-0.35191 l 0.6478,-49.061364 c 2.883,-1.834611 7.188,-4.171091 10.202,-4.171091 5.2417,0 6.3099,2.625001 6.4185,8.914071 l 0.7878,45.610104 c 2.4651,-0.38781 5.9664,1.24339 5.9987,-0.39591 l 0.9038,-45.998034 c 0.2319,-11.791681 1.3508,-17.564192 -11.7533,-17.564192 -5.3728,0 -11.6612,1.57328 -16.1166,4.063111 -2.4899,-2.620651 -6.1586,-4.063111 -11.7935,-4.063111 -1.5361,0 -2.9245,-0.0721 -4.243,-0.15595 z"
+       id="path3959-9-26-3-1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1223.2952,85.655406 -9.2281,-15.875942 -9.2281,-15.876132 h 18.4562 18.4561 l -9.2281,15.876132 z"
+       id="path3981-0-4-1-2"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#e19c9c;stroke-width:10.23778343;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 1272.1299,132.44473 V 75.679295"
+       id="path3983-4-9-2-9"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:10.28292942;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 1247.6099,132.4208 V 91.835136"
+       id="path3985-4-0-9-3"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:10.23778343;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1223.2938,132.77645 -0.022,-24.06433"
+       id="path3951-0-4-91-2-1"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:9.56036377;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <text
+       id="text4707-9"
+       y="138.64339"
+       x="1700.7795"
+       style="font-style:normal;font-weight:bold;font-size:131.04367065px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;fill:#3566a5;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;text-anchor:end;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+         y="138.64339"
+         x="1700.7795"
+         id="tspan4705-3"
+         sodipodi:role="line">2018</tspan></text>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer6"
+     inkscape:label="subtitle"
+     style="display:none">
+    <g
+       style="display:inline"
+       id="g1750"
+       transform="matrix(19.592171,0,0,19.592171,-1582.9761,-2384.3012)">
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.16364908px;line-height:100%;font-family:Galette;-inkscape-font-specification:'Galette Bold';letter-spacing:0px;word-spacing:0px;fill:#3465a4;fill-opacity:1;stroke:none;stroke-width:0.02372737px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         x="167.53929"
+         y="132.21951"
+         id="text1124"><tspan
+           sodipodi:role="line"
+           id="tspan1122"
+           x="167.53929"
+           y="132.21951"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#3465a4;fill-opacity:1;stroke-width:0.02372737px">0x2B || <tspan
+   style="letter-spacing:0px;fill:#a00000;fill-opacity:1"
+   id="tspan1454">!</tspan>0x2B</tspan><tspan
+           sodipodi:role="line"
+           x="167.53929"
+           y="135.49736"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#3465a4;fill-opacity:1;stroke-width:0.02372737px"
+           id="tspan1126">18-19 Oct. 2018</tspan><tspan
+           sodipodi:role="line"
+           x="167.53929"
+           y="138.77521"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#3465a4;fill-opacity:1;stroke-width:0.02372737px"
+           id="tspan1128">Berl   n</tspan></text>
+      <g
+         transform="matrix(0.20459945,0,0,0.20459945,152.35276,113.27741)"
+         id="g27740">
+        <g
+           id="g28309">
+          <path
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:normal;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.98000004;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6.24451828;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             d="m 3820.6562,472.26172 c -40.3422,0 -73.1445,32.3975 -73.1445,72.32812 0,30.32091 18.9212,56.28015 45.6875,67.02735 l 1.8555,-5.95508 c -24.2644,-9.91834 -41.2988,-33.51066 -41.2988,-61.07227 0,-36.51604 29.8935,-66.08398 66.9003,-66.08398 37.0069,0 66.8985,29.56794 66.8985,66.08398 0,24.66524 -13.6587,46.14338 -33.918,57.50977 -2.3907,1.34129 -4.8745,2.53952 -7.4355,3.58594 l 1.8535,5.96875 c 2.9828,-1.19355 5.8704,-2.56971 8.6426,-4.125 22.1465,-12.42531 37.1035,-35.96788 37.1035,-62.93946 0,-39.93062 -32.8023,-72.32812 -73.1446,-72.32812 z m 7.5,137.99414 c -2.4618,0.2706 -4.962,0.41602 -7.5,0.41602 -2.5028,0 -4.9696,-0.14473 -7.4003,-0.40821 l -1.8633,6.05469 c 3.0363,0.3807 6.1241,0.59767 9.2636,0.59766 3.182,0 6.3161,-0.2044 9.3926,-0.59571 z"
+             id="path3544-2"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ssccsssscccsscsccccc"
+             transform="matrix(0.04785074,0,0,0.04785074,-118.05951,92.995687)" />
+          <path
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a00000;stroke-width:6.34386444px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 3811.3887,563.87891 -30.2735,97.13867 h 78.9297 l -30.1523,-97.125 c -2.8017,1.31925 -5.9315,2.05859 -9.2364,2.05859 -3.3169,0 -6.4581,-0.74396 -9.2675,-2.07226 z m 9.2675,11.66406 19.3165,61.84961 h -38.4082 z"
+             transform="matrix(0.04785074,0,0,0.04785074,-118.05951,92.995687)"
+             id="path3548-6"
+             inkscape:connector-curvature="0" />
+          <path
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#a00000;stroke-width:0.3038334;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path3556-1"
+             d="m 65.796938,119.04618 c 0,0.56924 -0.463484,1.03071 -1.035215,1.03071 -0.571734,0 -1.035215,-0.46147 -1.035215,-1.03071 0,-0.56925 0.463481,-1.03071 1.035215,-1.03071 0.571731,0 1.035215,0.46146 1.035215,1.03071 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <path
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#3465a4;stroke-width:0.29880485;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+           id="path3552-8"
+           d="m 66.957088,119.05451 c 0,1.21246 -0.982899,2.19537 -2.195365,2.19537 -1.212466,0 -2.195365,-0.98291 -2.195365,-2.19537 0,-1.21246 0.982899,-2.19537 2.195365,-2.19537 1.212466,0 2.195365,0.98291 2.195365,2.19537 z"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/osmodevcon2019/artwork/intro.svg
+++ b/osmodevcon2019/artwork/intro.svg
@@ -1,0 +1,1372 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1920"
+   height="1080"
+   viewBox="0 0 1800 1012.5"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"
+   sodipodi:docname="intro.svg"
+   inkscape:export-filename="intro.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3374-5-7-7-0">
+      <stop
+         id="stop3376-8-6-4-2"
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3378-6-7-4-9"
+         style="stop-color:#729fcf;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3362-8-6-0-9">
+      <stop
+         id="stop3364-4-5-78-9"
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3366-7-6-6-4"
+         style="stop-color:#3465a4;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.837126"
+       y1="44.528019"
+       x2="21.036427"
+       y2="21.041553"
+       id="linearGradient3991-3-88-5"
+       xlink:href="#linearGradient7101-4-9-4-1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient7101-4-9-4-1">
+      <stop
+         id="stop7103-0-4-31-0"
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7105-6-8-4-3"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="39.06765"
+       y1="28.5"
+       x2="39.421204"
+       y2="10.934953"
+       id="linearGradient3993-1-9-7"
+       xlink:href="#linearGradient6979-9-2-2-8"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient6979-9-2-2-8">
+      <stop
+         id="stop6981-9-9-0-8"
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6983-0-3-6-6"
+         style="stop-color:#555753;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <linearGradient
+       id="linearGradient7131-6-1-5-7">
+      <stop
+         id="stop7133-4-5-2-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7135-6-9-5-0"
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <linearGradient
+       id="linearGradient7153-0-1-9-75">
+      <stop
+         id="stop7155-8-7-3-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7157-5-7-7-7"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.837126"
+       y1="44.528019"
+       x2="21.036427"
+       y2="21.041553"
+       id="linearGradient3991-3-88-5-3"
+       xlink:href="#linearGradient7101-4-9-4-1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="39.06765"
+       y1="28.5"
+       x2="39.421204"
+       y2="10.934953"
+       id="linearGradient3993-1-9-7-2"
+       xlink:href="#linearGradient6979-9-2-2-8"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <linearGradient
+       x1="24.837126"
+       y1="44.528019"
+       x2="21.036427"
+       y2="21.041553"
+       id="linearGradient3991-3-88-5-3-4"
+       xlink:href="#linearGradient7101-4-9-4-1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="39.06765"
+       y1="28.5"
+       x2="39.421204"
+       y2="10.934953"
+       id="linearGradient3993-1-9-7-2-4"
+       xlink:href="#linearGradient6979-9-2-2-8"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-3"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-1"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-7"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-6"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <linearGradient
+       x1="24.837126"
+       y1="44.528019"
+       x2="21.036427"
+       y2="21.041553"
+       id="linearGradient3991-3-88-5-3-5"
+       xlink:href="#linearGradient7101-4-9-4-1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="39.06765"
+       y1="28.5"
+       x2="39.421204"
+       y2="10.934953"
+       id="linearGradient3993-1-9-7-2-0"
+       xlink:href="#linearGradient6979-9-2-2-8"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-0"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-6"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-4"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-5"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       r="4.5250292"
+       fy="8.0709476"
+       fx="10.28125"
+       cy="8.0709476"
+       cx="10.28125"
+       gradientTransform="matrix(4.9499444,0,0,4.9510321,-11.38809,35.312197)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3637-3"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       inkscape:collect="always" />
+    <radialGradient
+       r="4.5250292"
+       fy="9.8424416"
+       fx="10.28125"
+       cy="9.8424416"
+       cx="10.28125"
+       gradientTransform="matrix(23.169932,0,0,7.6402677,-198.71238,8.843597)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3639-5"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       inkscape:collect="always" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9-2"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1-0"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2-2"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9-5"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-9"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-1"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-2"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-9"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9-20"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1-2"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2-3"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9-9"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       r="4.5250292"
+       fy="8.0709476"
+       fx="10.28125"
+       cy="8.0709476"
+       cx="10.28125"
+       gradientTransform="matrix(4.9499444,0,0,4.9510321,-11.38809,35.312197)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3637-3-3"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       inkscape:collect="always" />
+    <radialGradient
+       r="4.5250292"
+       fy="9.8424416"
+       fx="10.28125"
+       cy="9.8424416"
+       cx="10.28125"
+       gradientTransform="matrix(23.169932,0,0,7.6402677,-198.71238,8.843597)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3639-5-5"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       inkscape:collect="always" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9-0"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1-9"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2-36"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9-2"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.35"
+     inkscape:cx="250.30595"
+     inkscape:cy="523.36137"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer5"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1080"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:measure-start="63.3968,-113.628"
+     inkscape:measure-end="34.3452,-129.3"
+     inkscape:snap-page="true"
+     inkscape:pagecheckerboard="true"
+     gridtolerance="5"
+     objecttolerance="10"
+     guidetolerance="10"
+     inkscape:lockguides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid20483" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     transform="translate(0,-67.5)">
+    <rect
+       style="opacity:1;fill:#fffff3;fill-opacity:1;stroke:none;stroke-width:1.00031257;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect20497"
+       width="1800"
+       height="1012.4999"
+       x="0"
+       y="67.5"
+       inkscape:label="bg color" />
+    <rect
+       style="display:inline;opacity:1;fill:#7ba4d9;fill-opacity:1;stroke:none;stroke-width:0.96588516;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect20265"
+       width="1800"
+       height="339.50528"
+       x="1.1368684e-13"
+       y="740.49463"
+       inkscape:label="Bande Blau Unten" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Text"
+     style="display:inline"
+     transform="translate(0,-67.5)">
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot1014"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;opacity:0;fill:#555555;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       transform="matrix(0.9375,0,0,0.9375,596.82417,403.33401)"
+       inkscape:label="title"
+       inkscape:transform-center-x="4.0178571"
+       inkscape:transform-center-y="-24.107143"><flowRegion
+         id="flowRegion20435"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1"><rect
+           id="rect20437"
+           width="604.28571"
+           height="189.99998"
+           x="61.42857"
+           y="67.714287"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1" /></flowRegion><flowPara
+         id="flowPara24792"
+         style="font-size:192px">Pause</flowPara></flowRoot>    <flowRoot
+       xml:space="preserve"
+       id="flowRoot25337"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"><flowRegion
+         id="flowRegion25339"><rect
+           id="rect25341"
+           width="14.285714"
+           height="90"
+           x="902.85712"
+           y="472.85715" /></flowRegion><flowPara
+         id="flowPara25343" /></flowRoot>    <flowRoot
+       inkscape:transform-center-y="-24.107143"
+       inkscape:transform-center-x="4.0178571"
+       inkscape:label="title"
+       transform="matrix(0.9375,0,0,0.9375,604.85988,449.04839)"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;opacity:0;fill:#555555;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="pause"
+       xml:space="preserve"><flowRegion
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1"
+         id="flowRegion25395"><rect
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1"
+           y="67.714287"
+           x="61.42857"
+           height="189.99998"
+           width="604.28571"
+           id="rect25393" /></flowRegion><flowPara
+         style="font-size:192px"
+         id="flowPara25397">Pause</flowPara></flowRoot>    <flowRoot
+       xml:space="preserve"
+       id="title"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS Bold';letter-spacing:0px;word-spacing:0px;display:inline;opacity:0;fill:#555555;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       transform="matrix(0.9375,0,0,0.9375,-0.65307494,431.45901)"
+       inkscape:label="title"
+       inkscape:transform-center-x="4.0178571"
+       inkscape:transform-center-y="-24.107143"><flowRegion
+         id="flowRegion20435-6"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS Bold';fill:#555555;fill-opacity:1"><rect
+           id="rect20437-7"
+           width="1198.5714"
+           height="192.85713"
+           x="61.42857"
+           y="67.714287"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS Bold';fill:#555555;fill-opacity:1" /></flowRegion><flowPara
+         id="flowPara20439"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:53.33333206px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS Bold';fill:#555555;fill-opacity:1">$title</flowPara></flowRoot>    <flowRoot
+       xml:space="preserve"
+       id="personnames"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.66666794px;line-height:125%;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0;fill:#232323;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;"
+       transform="matrix(0.9375,0,0,0.9375,-18.078613,-6.9778852)"
+       inkscape:label="personnames"><flowRegion
+         id="flowRegion20443"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.66666794px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;"><rect
+           id="rect20445"
+           width="1117.1428"
+           height="48.57143"
+           x="81.428574"
+           y="813.42859"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.66666794px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;" /></flowRegion><flowPara
+         id="flowPara3872">$personnames</flowPara></flowRoot>    <flowRoot
+       xml:space="preserve"
+       id="subtitle"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS Bold';letter-spacing:0px;word-spacing:0px;display:inline;opacity:0;fill:#555555;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;"
+       transform="matrix(0.9375,0,0,0.9375,-13.101196,-5.1528777e-6)"
+       inkscape:label="subtitle"><flowRegion
+         id="flowRegion20471"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS Bold';fill:#555555;fill-opacity:1;"><rect
+           id="rect20473"
+           width="1930"
+           height="52.857143"
+           x="75.714287"
+           y="724.85712"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS Bold';fill:#555555;fill-opacity:1;" /></flowRegion><flowPara
+         id="flowPara20477"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS Bold';fill:#555555;fill-opacity:1;">$subtitle</flowPara></flowRoot>  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="title">
+    <g
+       inkscape:groupmode="layer"
+       id="layer5"
+       inkscape:label="title_path"
+       style="display:inline">
+      <g
+         aria-label="DeCon"
+         style="font-style:normal;font-weight:bold;font-size:131.04367065px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Yanone Kaffeesatz Bold';letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         id="text4707-97-4" />
+      <g
+         style="display:inline"
+         id="g3732-6-8"
+         transform="matrix(2.0475567,0,0,2.0475567,842.47193,-71.674635)">
+        <path
+           inkscape:connector-curvature="0"
+           d="m 60.69548,67.493897 c 0,11.5675 -9.48796,20.9448 -21.19195,20.9448 -11.703989,0 -21.191949,-9.3773 -21.191949,-20.9448 0,-11.5674 9.48796,-20.9447 21.191949,-20.9447 11.70399,0 21.19195,9.3773 21.19195,20.9447 z"
+           id="path3544-1-7"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;opacity:0.8;fill:url(#radialGradient3637-3-3);fill-opacity:1;stroke:url(#radialGradient3639-5-5);stroke-width:1.46151388;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+        <g
+           transform="matrix(1.4615138,0,0,2.5218672,4.4272,31.547917)"
+           id="g3546-8-9"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:#000000;fill-opacity:1;stroke:none">
+          <path
+             inkscape:connector-curvature="0"
+             d="m 24,13 -8.1875,15.225744 c 11.445471,0 5.976697,0 16.34375,0 z m 0,4.96875 4,7.421875 h -7.953125 z"
+             id="path3548-79-2"
+             style="fill:url(#linearGradient3991-3-88-5-3);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3993-1-9-7-2);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="M 26.355979,42.522608 20,21.277828 13.644021,42.522609"
+             transform="matrix(1,0,0,0.57953638,4,2.7937247)"
+             id="path3550-2-0"
+             style="fill:none;stroke:#ffffff;stroke-width:1.31358945px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+        </g>
+        <path
+           inkscape:connector-curvature="0"
+           d="m 53.38791,67.493897 c 0,7.6681 -6.21625,13.8844 -13.88438,13.8844 -7.66813,0 -13.884379,-6.2163 -13.884379,-13.8844 0,-7.6681 6.216249,-13.8844 13.884379,-13.8844 7.66813,0 13.88438,6.2163 13.88438,13.8844 z"
+           id="path3552-0-2"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:url(#radialGradient3995-7-4-0-2-2-0-9-0);fill-opacity:1;stroke:url(#radialGradient3997-3-3-4-7-7-6-1-9);stroke-width:1.46151388;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+        <g
+           transform="matrix(3.2735609,0,0,3.2593101,-24.33091,59.292917)"
+           id="g3554-2-3"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:#000000;fill-opacity:1;stroke:none">
+          <path
+             inkscape:connector-curvature="0"
+             d="M 11,2.25 C 11,3.2164983 10.195512,4 9.203125,4 8.2107383,4 7.40625,3.2164983 7.40625,2.25 7.40625,1.2835017 8.2107383,0.5 9.203125,0.5 10.195512,0.5 11,1.2835017 11,2.25 Z"
+             transform="matrix(1.1130433,0,0,1.1428572,9.2565233,-0.07142864)"
+             id="path3556-3-7"
+             style="fill:url(#radialGradient3999-1-4-6-0-0-3-2-36);fill-opacity:1;stroke:#555753;stroke-width:0.39671427;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="M 20,1.5 C 20,1.7761424 19.776142,2 19.5,2 19.223858,2 19,1.7761424 19,1.5 19,1.2238576 19.223858,1 19.5,1 19.776142,1 20,1.2238576 20,1.5 Z"
+             transform="matrix(1.8125,0,0,1.8125,-16.465404,-0.9288198)"
+             id="path3558-7-5"
+             style="fill:#ffffff;fill-opacity:1;stroke:none" />
+        </g>
+        <path
+           inkscape:connector-curvature="0"
+           d="m 44.61882,67.441097 c 0,2.8124 -2.2902,5.0924 -5.1153,5.0924 -2.8251,0 -5.1153,-2.28 -5.1153,-5.0924 0,-2.8125 2.2902,-5.0924 5.1153,-5.0924 2.8251,0 5.1153,2.2799 5.1153,5.0924 z"
+           id="path3560-5-9"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:url(#radialGradient4001-9-6-9-6-60-6-9-2);stroke-width:1.46151364;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <g
+         aria-label="Os"
+         style="font-style:normal;font-weight:normal;font-size:131.04367065px;line-height:125%;font-family:Sans;letter-spacing:0.28665793px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         id="text3743-6-9-2">
+        <path
+           d="m 972.19144,89.895193 c 0,37.740577 6.68323,47.568857 23.58786,47.568857 17.2978,0 24.7673,-11.92498 24.7673,-47.961988 0,-35.381791 -6.2901,-46.127372 -23.32582,-46.127372 -16.90463,0 -25.02934,11.662887 -25.02934,46.520503 z m 11.92498,2.620874 c 0,-28.305433 3.66922,-38.264752 12.84228,-38.264752 9.4351,0 12.056,9.3041 12.056,35.512835 0,26.73291 -3.2761,36.82327 -12.71122,36.82327 -9.3041,0 -12.18706,-9.69723 -12.18706,-34.071353 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';letter-spacing:0.28665793px;fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           id="path381" />
+        <path
+           d="m 1050.0211,69.452381 c -14.6768,0 -21.3601,6.290096 -21.3601,15.463153 0,4.324441 1.5726,9.042013 7.4695,13.890629 l 12.7113,10.876627 c 3.9313,3.53818 5.2417,6.68322 5.2417,10.2214 0,5.24175 -3.9313,8.12471 -10.6145,8.12471 -5.1107,0 -9.3041,-1.04835 -13.1044,-3.27609 -1.4415,2.35879 -1.8346,4.58653 -1.8346,6.15905 0,4.58653 6.6832,6.68323 15.9873,6.68323 13.3665,0 21.6222,-6.55218 21.6222,-18.21507 0,-6.55218 -2.0967,-10.87663 -7.7316,-16.38046 l -12.187,-9.828275 c -4.4555,-3.669223 -5.2418,-5.765921 -5.2418,-8.124708 0,-4.062353 4.1934,-6.290096 10.3525,-6.290096 4.9796,0 8.911,1.04835 12.8423,3.407136 1.4414,-1.572524 2.3587,-3.669223 2.3587,-5.372791 0,-2.620873 -3.014,-7.338445 -16.5115,-7.338445 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';letter-spacing:0.28665793px;fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           id="path383" />
+      </g>
+      <g
+         aria-label="o"
+         style="font-style:normal;font-weight:normal;font-size:81.90226746px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         id="text3760-7-2-8">
+        <path
+           d="m 1154.9617,103.52374 c 0,29.48482 7.0764,34.07135 20.5739,34.07135 14.0216,0 21.4911,-10.09036 21.4911,-34.46449 0,-26.601861 -6.5522,-33.678219 -20.3118,-33.678219 -13.7595,0 -21.7532,10.090362 -21.7532,34.071359 z m 11.5318,0.26208 c 0,-20.44281 4.0624,-25.029339 9.8283,-25.029339 6.1591,0 9.1731,3.669223 9.1731,24.505169 0,20.44281 -4.0624,25.29143 -9.6973,25.29143 -6.028,0 -9.3041,-3.14505 -9.3041,-24.76726 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           id="path386" />
+      </g>
+      <g
+         aria-label="DevCon"
+         style="font-style:normal;font-weight:bold;font-size:131.04367065px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Yanone Kaffeesatz Bold';letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         id="text4707-97-7">
+        <path
+           d="m 1209.8369,45.864447 c -2.883,0 -3.6693,0.917306 -3.6693,2.620873 v 89.1097 h 16.9047 c 17.6909,0 25.0293,-15.46316 25.0293,-50.451817 0,-33.678223 -8.2557,-41.278756 -25.6845,-41.278756 z m 21.3601,39.706232 c 0,33.285091 -3.6692,38.133711 -7.7316,38.133711 h -2.6209 V 59.230901 h 2.4899 c 4.7175,0 7.8626,2.882961 7.8626,26.339778 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           id="path389" />
+        <path
+           d="m 1276.5565,70.762744 c -12.3181,0 -23.0637,5.503835 -23.0637,37.216406 0,24.89829 8.3868,30.9263 20.3118,30.9263 10.2214,0 18.6082,-2.88296 18.6082,-8.1247 0,-3.01401 -0.3931,-7.20741 -1.1794,-9.82828 -4.5865,2.22774 -9.173,3.66922 -13.8906,3.66922 -6.2901,0 -8.1247,-3.66922 -8.5179,-11.92497 6.4212,-0.13104 16.2495,-0.65522 22.6706,-1.96566 1.3104,-5.1107 1.8346,-12.318101 1.8346,-18.608197 0,-15.201066 -6.2901,-21.360119 -16.7736,-21.360119 z m -1.9656,12.711236 c 3.2761,0 4.4554,1.310437 4.4554,9.697232 0,2.096699 -0.131,5.241747 -0.6552,6.814271 -1.9656,0.917307 -6.028,1.179397 -9.6972,1.179397 0.3931,-11.924978 1.8346,-17.6909 5.897,-17.6909 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           id="path391" />
+        <path
+           d="m 1308.3612,131.69805 c 0.7863,3.66922 2.3588,6.55218 6.1591,6.55218 2.7519,0 7.6005,-0.13104 10.6145,-0.65521 l 13.1044,-65.521839 c -15.07,0 -15.07,0 -15.4632,2.882961 l -1.8346,15.987328 c -1.3104,11.26976 -2.4898,31.31944 -2.4898,31.31944 h -0.2621 c 0,0 -1.1794,-20.04968 -2.6209,-31.31944 l -2.3588,-18.870289 c -16.7735,0 -16.9046,0 -15.9873,4.324441 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           id="path393" />
+        <path
+           d="m 1368.2584,43.898792 c -11.7939,0 -26.2087,7.86262 -26.2087,50.844944 0,36.692224 7.0764,44.816934 21.8843,44.816934 9.9593,0 15.9873,-3.53818 15.9873,-9.69723 0,-3.14505 -0.9173,-6.42114 -1.9656,-8.64888 -2.4899,1.31043 -6.1591,1.96565 -10.2214,1.96565 -7.3385,0 -10.2215,-6.81427 -10.2215,-29.615867 0,-28.56752 6.8143,-35.381791 14.2838,-35.381791 2.883,0 5.2418,1.048349 6.8143,2.227742 1.0483,-2.227742 2.0967,-5.241746 2.0967,-8.779925 0,-3.931311 -1.3105,-7.731577 -12.4492,-7.731577 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           id="path395" />
+        <path
+           d="m 1382.3395,104.70306 c 0,29.35378 6.5522,34.20239 20.7049,34.20239 14.1527,0 21.4911,-9.43514 21.4911,-34.72657 0,-26.470821 -6.4211,-33.416136 -20.4428,-33.416136 -13.8906,0 -21.7532,10.221407 -21.7532,33.940316 z m 16.1184,-0.13105 c 0,-18.6082 2.2277,-21.229073 5.1107,-21.229073 3.8002,0 4.8486,2.358786 4.8486,21.229073 0,20.18073 -2.4899,22.14638 -4.9797,22.14638 -3.2761,0 -4.9796,-1.70357 -4.9796,-22.14638 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           id="path397" />
+        <path
+           d="m 1430.7683,137.59502 c 14.4148,0 14.6769,0 14.6769,-2.62088 V 84.915461 c 1.4415,-1.048349 3.2761,-1.572524 4.9797,-1.572524 3.6692,0 4.3244,2.096699 4.3244,8.910969 v 45.341114 c 14.8079,0 15.2011,0 15.2011,-2.62088 V 87.667378 c 0,-13.104367 -5.6349,-16.904634 -18.8703,-16.904634 -6.5522,0 -16.2494,2.358787 -20.3118,4.324442 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           id="path399" />
+      </g>
+      <path
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:64px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Andale Mono';writing-mode:lr-tb;display:inline;fill:#a00000;fill-opacity:1;stroke:#a00000;stroke-width:2.04755735;stroke-opacity:1"
+         d="m 1095.5631,70.382827 -8.8741,15.272702 -4.0593,-6.986499 1.2039,55.02807 c 3.887,-2.71488 5.3164,1.47607 5.3748,-0.61985 l 1.4237,-51.00496 c 3.0141,-1.572521 6.0272,-2.227521 8.9101,-2.227521 5.2418,0 7.3232,1.833021 7.4545,6.550591 l 0.5798,47.16175 c 3.6356,-1.03422 6.9193,0.79411 6.9344,-0.35191 l 0.6478,-49.06135 c 2.883,-1.834612 7.188,-4.171092 10.202,-4.171092 5.2417,0 6.3099,2.625002 6.4185,8.914072 l 0.7878,45.61009 c 2.4651,-0.38781 5.9664,1.24341 5.9987,-0.39591 l 0.9038,-45.99802 c 0.2319,-11.791682 1.3508,-17.564193 -11.7533,-17.564193 -5.3728,0 -11.6612,1.57328 -16.1166,4.06311 -2.4899,-2.62065 -6.1586,-4.06311 -11.7935,-4.06311 -1.5361,0 -2.9245,-0.0721 -4.243,-0.15595 z"
+         id="path3959-9-26-3-1-6"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 1086.688,85.65542 -9.2281,-15.875944 -9.2281,-15.876132 h 18.4562 18.4561 l -9.2281,15.876132 z"
+         id="path3981-0-4-1-2-1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#e19c9c;stroke-width:10.23778343;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 1135.5227,132.44473 V 75.679308"
+         id="path3983-4-9-2-9-2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:10.28292942;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 1111.0027,132.42082 V 91.83515"
+         id="path3985-4-0-9-3-9"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:10.23778343;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 1086.6866,132.77647 -0.022,-24.06433"
+         id="path3951-0-4-91-2-1-3"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:9.56036377;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <g
+         aria-label="2019"
+         style="font-style:normal;font-weight:bold;font-size:131.04367065px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;fill:#3566a5;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         id="text4707-9-1">
+        <path
+           d="m 1497.8502,77.970167 c 4.4555,-2.358786 12.9734,-3.93131 17.1667,-3.93131 4.7176,0 7.7316,2.48983 7.7316,6.945315 0,10.876624 -14.8079,22.670558 -25.8156,41.933978 -2.8829,5.1107 -3.4071,6.94531 -3.4071,11.66288 0,0.39313 0,2.48983 0.5242,4.06236 h 43.2444 c 3.2761,0 3.4071,-3.01401 3.4071,-15.20107 0,0 -7.0764,1.44148 -17.953,1.44148 h -9.6972 c 12.056,-19.52551 26.6019,-30.664218 26.6019,-46.389458 0,-11.924974 -5.2418,-18.477158 -20.0497,-18.477158 -11.794,0 -23.5879,3.276092 -23.5879,7.338446 0,2.227742 0.1311,6.945315 1.8346,10.745581 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;text-anchor:end;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+           id="path402" />
+        <path
+           d="m 1545.9944,99.85446 c 0,24.8983 4.0624,39.96832 23.1948,39.96832 18.8703,0 23.981,-14.93898 23.981,-44.816935 0,-22.932643 -6.9453,-34.988661 -23.7189,-34.988661 -16.5115,0 -23.4569,13.628542 -23.4569,39.837276 z m 15.9874,0.52418 c 0,-16.773595 1.1794,-27.519176 8.2557,-27.519176 6.028,0 7.4695,8.124708 7.4695,22.146381 0,23.587865 -2.6209,31.712565 -7.9937,31.712565 -6.8142,0 -7.7315,-6.55218 -7.7315,-26.33977 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;text-anchor:end;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+           id="path404" />
+        <path
+           d="m 1603.7048,76.528687 c 0,0 5.6349,-1.310437 12.4492,-1.572524 l -1.1794,49.927637 c -12.1871,0 -16.6425,0.78626 -16.6425,4.06236 0,3.40713 0.131,6.42114 0.3931,9.69723 h 43.6375 c 3.2761,0 3.2761,-3.14505 3.2761,-14.28376 0,0 -3.9313,0.52417 -7.9936,0.52417 h -7.3385 l 1.5725,-64.080354 c -0.6552,-0.524174 -2.6208,-0.786262 -3.8002,-0.786262 -6.9453,0 -26.6019,4.455485 -26.6019,7.46949 0,3.538179 0.6552,6.290096 2.2277,9.042013 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;text-anchor:end;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+           id="path406" />
+        <path
+           d="m 1663.512,138.3813 c -3.2761,0 -6.6833,-0.65522 -9.3041,-1.44148 -0.7863,2.75192 -1.3105,7.2074 -1.3105,9.69723 0,4.32444 5.5039,5.63488 12.5802,5.63488 23.3258,0 32.2368,-16.77359 32.6299,-51.36912 -0.6552,-33.54718 -3.9313,-42.065019 -22.8016,-42.065019 -15.7253,0 -24.6362,9.697232 -24.6362,32.760918 0,16.773591 7.3384,26.863951 17.8219,26.863951 7.4695,0 11.6629,-2.22774 15.2011,-6.68323 -0.9173,14.41481 -4.8486,26.60187 -20.1807,26.60187 z m 9.5661,-33.41614 c -5.3727,0 -7.9936,-5.896962 -7.9936,-14.938975 0,-12.318105 4.4555,-18.21507 10.4835,-18.21507 6.6832,0 8.5178,6.159052 8.5178,26.339778 v 0.786262 c -3.5382,4.586525 -7.2074,6.028005 -11.0077,6.028005 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;text-anchor:end;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+           id="path408" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer4"
+       inkscape:label="title_font"
+       style="display:none">
+      <g
+         style="display:inline"
+         id="g3732-6"
+         transform="matrix(2.0475567,0,0,2.0475567,842.47193,-71.674635)">
+        <path
+           inkscape:connector-curvature="0"
+           d="m 60.69548,67.493897 c 0,11.5675 -9.48796,20.9448 -21.19195,20.9448 -11.703989,0 -21.191949,-9.3773 -21.191949,-20.9448 0,-11.5674 9.48796,-20.9447 21.191949,-20.9447 11.70399,0 21.19195,9.3773 21.19195,20.9447 z"
+           id="path3544-1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;opacity:0.8;fill:url(#radialGradient3637-3);fill-opacity:1;stroke:url(#radialGradient3639-5);stroke-width:1.46151388;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+        <g
+           transform="matrix(1.4615138,0,0,2.5218672,4.4272,31.547917)"
+           id="g3546-8"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:#000000;fill-opacity:1;stroke:none">
+          <path
+             inkscape:connector-curvature="0"
+             d="m 24,13 -8.1875,15.225744 c 11.445471,0 5.976697,0 16.34375,0 z m 0,4.96875 4,7.421875 h -7.953125 z"
+             id="path3548-79"
+             style="fill:url(#linearGradient3991-3-88-5);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3993-1-9-7);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="M 26.355979,42.522608 20,21.277828 13.644021,42.522609"
+             transform="matrix(1,0,0,0.57953638,4,2.7937247)"
+             id="path3550-2"
+             style="fill:none;stroke:#ffffff;stroke-width:1.31358945px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+        </g>
+        <path
+           inkscape:connector-curvature="0"
+           d="m 53.38791,67.493897 c 0,7.6681 -6.21625,13.8844 -13.88438,13.8844 -7.66813,0 -13.884379,-6.2163 -13.884379,-13.8844 0,-7.6681 6.216249,-13.8844 13.884379,-13.8844 7.66813,0 13.88438,6.2163 13.88438,13.8844 z"
+           id="path3552-0"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:url(#radialGradient3995-7-4-0-2-2-0-9);fill-opacity:1;stroke:url(#radialGradient3997-3-3-4-7-7-6-1);stroke-width:1.46151388;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+        <g
+           transform="matrix(3.2735609,0,0,3.2593101,-24.33091,59.292917)"
+           id="g3554-2"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:#000000;fill-opacity:1;stroke:none">
+          <path
+             inkscape:connector-curvature="0"
+             d="M 11,2.25 C 11,3.2164983 10.195512,4 9.203125,4 8.2107383,4 7.40625,3.2164983 7.40625,2.25 7.40625,1.2835017 8.2107383,0.5 9.203125,0.5 10.195512,0.5 11,1.2835017 11,2.25 Z"
+             transform="matrix(1.1130433,0,0,1.1428572,9.2565233,-0.07142864)"
+             id="path3556-3"
+             style="fill:url(#radialGradient3999-1-4-6-0-0-3-2);fill-opacity:1;stroke:#555753;stroke-width:0.39671427;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="M 20,1.5 C 20,1.7761424 19.776142,2 19.5,2 19.223858,2 19,1.7761424 19,1.5 19,1.2238576 19.223858,1 19.5,1 19.776142,1 20,1.2238576 20,1.5 Z"
+             transform="matrix(1.8125,0,0,1.8125,-16.465404,-0.9288198)"
+             id="path3558-7"
+             style="fill:#ffffff;fill-opacity:1;stroke:none" />
+        </g>
+        <path
+           inkscape:connector-curvature="0"
+           d="m 44.61882,67.441097 c 0,2.8124 -2.2902,5.0924 -5.1153,5.0924 -2.8251,0 -5.1153,-2.28 -5.1153,-5.0924 0,-2.8125 2.2902,-5.0924 5.1153,-5.0924 2.8251,0 5.1153,2.2799 5.1153,5.0924 z"
+           id="path3560-5"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:url(#radialGradient4001-9-6-9-6-60-6-9);stroke-width:1.46151364;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:131.04367065px;line-height:125%;font-family:Sans;letter-spacing:0.28665793px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         x="968.26013"
+         y="136.28465"
+         id="text3743-6-9"><tspan
+           sodipodi:role="line"
+           id="tspan3745-0-2"
+           x="968.26013"
+           y="136.28465"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';letter-spacing:0.28665793px;fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           dx="0 0">Os</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:81.90226746px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         x="1151.8167"
+         y="136.28465"
+         id="text3760-7-2"><tspan
+           sodipodi:role="line"
+           id="tspan3762-0-8"
+           x="1151.8167"
+           y="136.28465"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';fill:#a00000;fill-opacity:1;stroke-width:2.04755735">o</tspan></text>
+      <text
+         id="text4707-97"
+         y="137.59502"
+         x="1202.2363"
+         style="font-style:normal;font-weight:bold;font-size:131.04367065px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Yanone Kaffeesatz Bold';letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           y="137.59502"
+           x="1202.2363"
+           id="tspan4705-36"
+           sodipodi:role="line">DevCon</tspan></text>
+      <path
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:64px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Andale Mono';writing-mode:lr-tb;display:inline;fill:#a00000;fill-opacity:1;stroke:#a00000;stroke-width:2.04755735;stroke-opacity:1"
+         d="m 1095.5631,70.382821 -8.8741,15.272701 -4.0593,-6.986499 1.2039,55.028077 c 3.887,-2.71488 5.3164,1.47606 5.3748,-0.61985 l 1.4237,-51.004967 c 3.0141,-1.57252 6.0272,-2.227521 8.9101,-2.227521 5.2418,0 7.3232,1.833021 7.4545,6.550591 l 0.5798,47.161757 c 3.6356,-1.03422 6.9193,0.79411 6.9344,-0.35191 l 0.6478,-49.061357 c 2.883,-1.834612 7.188,-4.171091 10.202,-4.171091 5.2417,0 6.3099,2.625001 6.4185,8.914071 l 0.7878,45.610097 c 2.4651,-0.38781 5.9664,1.2434 5.9987,-0.39591 l 0.9038,-45.998027 c 0.2319,-11.791682 1.3508,-17.564192 -11.7533,-17.564192 -5.3728,0 -11.6612,1.573279 -16.1166,4.06311 -2.4899,-2.62065 -6.1586,-4.06311 -11.7935,-4.06311 -1.5361,0 -2.9245,-0.0721 -4.243,-0.155951 z"
+         id="path3959-9-26-3-1"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 1086.688,85.655413 -9.2281,-15.875943 -9.2281,-15.876132 h 18.4562 18.4561 l -9.2281,15.876132 z"
+         id="path3981-0-4-1-2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#e19c9c;stroke-width:10.23778343;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 1135.5227,132.44473 V 75.679302"
+         id="path3983-4-9-2-9"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:10.28292942;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 1111.0027,132.42081 V 91.835143"
+         id="path3985-4-0-9-3"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:10.23778343;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 1086.6866,132.77646 -0.022,-24.06433"
+         id="path3951-0-4-91-2-1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:9.56036377;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <text
+         id="text4707-9"
+         y="138.64339"
+         x="1700.7795"
+         style="font-style:normal;font-weight:bold;font-size:131.04367065px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;fill:#3566a5;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;text-anchor:end;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+           y="138.64339"
+           x="1700.7795"
+           id="tspan4705-3"
+           sodipodi:role="line">2019</tspan></text>
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer6"
+     inkscape:label="subtitle">
+    <g
+       inkscape:groupmode="layer"
+       id="layer7"
+       inkscape:label="subtitle_path"
+       style="display:inline">
+      <g
+         aria-label="Osmocom Developer Conference 2019, 26-29 April 2019, Berl   n"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:61.98275375px;line-height:100%;font-family:Galette;-inkscape-font-specification:'Galette Bold';letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:0.46487072px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="text1124-2">
+        <path
+           d="m 16.924401,961.82056 c 0,17.85103 3.16112,22.49974 11.156895,22.49974 8.181724,0 11.714741,-5.64043 11.714741,-22.68569 0,-16.73535 -2.975172,-21.81793 -11.03293,-21.81793 -7.995775,0 -11.838706,5.51646 -11.838706,22.00388 z m 5.64043,1.23965 c 0,-13.38827 1.735518,-18.09896 6.07431,-18.09896 4.462759,0 5.702414,4.40077 5.702414,16.79732 0,12.64449 -1.549569,17.41716 -6.012327,17.41716 -4.400776,0 -5.764397,-4.58673 -5.764397,-16.11552 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1354"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 53.601726,952.15125 c -6.942068,0 -10.103189,2.97517 -10.103189,7.31396 0,2.04543 0.743793,4.27681 3.533017,6.57017 l 6.012327,5.14457 c 1.859483,1.67354 2.47931,3.16112 2.47931,4.83466 0,2.47931 -1.859482,3.84293 -5.020603,3.84293 -2.417327,0 -4.400775,-0.49586 -6.198275,-1.54957 -0.68181,1.11569 -0.867759,2.1694 -0.867759,2.91319 0,2.16939 3.161121,3.16112 7.561896,3.16112 6.322241,0 10.227155,-3.09914 10.227155,-8.6156 0,-3.09914 -0.991724,-5.14457 -3.656983,-7.74785 l -5.764396,-4.6487 c -2.107413,-1.73552 -2.47931,-2.72725 -2.47931,-3.84294 0,-1.92146 1.983448,-2.97517 4.896638,-2.97517 2.355344,0 4.214827,0.49586 6.074309,1.61155 0.681811,-0.74379 1.11569,-1.73551 1.11569,-2.54129 0,-1.23965 -1.425603,-3.47103 -7.809827,-3.47103 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1356"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 78.128495,983.76245 c 5.082586,0 5.020603,0 5.020603,-0.99172 v -24.97905 c 1.363621,-0.86776 2.727241,-1.17767 4.152845,-1.17767 2.47931,0 3.037155,1.23965 3.037155,4.21482 v 22.93362 c 4.834654,0 5.020603,0 5.020603,-0.99172 v -21.87991 c 0,-5.57845 -0.743793,-8.73957 -6.942069,-8.73957 -2.541293,0 -5.516465,0.74379 -7.623878,1.92146 -1.177673,-1.23965 -2.91319,-1.92146 -5.578448,-1.92146 -3.409052,0 -6.632155,0.80577 -9.359396,2.04543 v 29.56577 c 4.834655,0 5.020603,0 5.020603,-0.99172 v -25.165 c 1.425603,-0.74379 2.851207,-1.05371 4.214827,-1.05371 2.47931,0 2.975172,0.86776 3.037155,3.09914 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1358"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 99.357589,968.26676 c 0,13.94612 3.347071,16.11552 9.731291,16.11552 6.63216,0 10.16517,-4.77267 10.16517,-16.30147 0,-12.58249 -3.09914,-15.92956 -9.60732,-15.92956 -6.50819,0 -10.289141,4.77267 -10.289141,16.11551 z m 5.454481,0.12397 c 0,-9.66931 1.92147,-11.83871 4.64871,-11.83871 2.91319,0 4.33879,1.73552 4.33879,11.59078 0,9.66931 -1.92147,11.96267 -4.58672,11.96267 -2.85121,0 -4.40078,-1.48759 -4.40078,-11.71474 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1360"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 138.85222,954.94047 c 0,-1.61155 -2.29336,-2.78922 -5.14456,-2.78922 -5.14457,0 -11.1569,1.92146 -11.1569,16.79732 0,13.07836 3.34707,15.43371 9.23543,15.43371 4.09086,0 6.94207,-1.48759 6.94207,-3.16112 0,-0.80578 -0.18595,-1.61155 -0.49586,-2.72724 -1.05371,0.68181 -2.91319,1.4256 -4.89664,1.4256 -3.78095,0 -5.51647,-2.23138 -5.51647,-10.97095 0,-11.03293 3.22311,-12.33456 6.1363,-12.33456 1.67353,0 3.34707,0.55784 4.33879,1.11568 0.43388,-1.0537 0.55784,-2.10741 0.55784,-2.78922 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1362"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 140.76013,968.26676 c 0,13.94612 3.34707,16.11552 9.73129,16.11552 6.63216,0 10.16517,-4.77267 10.16517,-16.30147 0,-12.58249 -3.09913,-15.92956 -9.60732,-15.92956 -6.50819,0 -10.28914,4.77267 -10.28914,16.11551 z m 5.45448,0.12397 c 0,-9.66931 1.92147,-11.83871 4.64871,-11.83871 2.91319,0 4.33879,1.73552 4.33879,11.59078 0,9.66931 -1.92146,11.96267 -4.58672,11.96267 -2.85121,0 -4.40078,-1.48759 -4.40078,-11.71474 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1364"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 177.15563,983.76245 c 5.08258,0 5.0206,0 5.0206,-0.99172 v -24.97905 c 1.36362,-0.86776 2.72724,-1.17767 4.15285,-1.17767 2.47931,0 3.03715,1.23965 3.03715,4.21482 v 22.93362 c 4.83466,0 5.0206,0 5.0206,-0.99172 v -21.87991 c 0,-5.57845 -0.74379,-8.73957 -6.94206,-8.73957 -2.5413,0 -5.51647,0.74379 -7.62388,1.92146 -1.17767,-1.23965 -2.91319,-1.92146 -5.57845,-1.92146 -3.40905,0 -6.63216,0.80577 -9.3594,2.04543 v 29.56577 c 4.83466,0 5.02061,0 5.02061,-0.99172 v -25.165 c 1.4256,-0.74379 2.8512,-1.05371 4.21482,-1.05371 2.47931,0 2.97518,0.86776 3.03716,3.09914 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1366"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 210.98272,940.37452 c -1.36362,0 -1.67353,0.43388 -1.67353,1.17768 v 42.21025 h 7.74784 c 7.62388,0 12.08664,-5.76439 12.08664,-23.92534 0,-15.06181 -4.02888,-19.46259 -12.14862,-19.46259 z m 12.39655,18.96673 c 0,17.16922 -3.03715,19.64853 -6.26025,19.64853 h -2.78923 v -33.96655 h 2.85121 c 4.15284,0 6.19827,2.85121 6.19827,14.31802 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1368"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 243.80743,952.15125 c -5.45448,0 -10.97095,2.23138 -10.97095,17.72706 0,12.08664 4.15285,14.50397 9.91724,14.50397 4.64871,0 8.55362,-1.48759 8.55362,-3.40905 0,-0.99173 -0.12396,-2.47931 -0.43388,-3.40905 -2.10741,1.17767 -4.58672,1.92146 -7.06603,1.92146 -3.78095,0 -5.51647,-1.73552 -5.7644,-8.30569 2.97517,0 8.67759,-0.18595 12.9544,-0.99172 0.49586,-2.23138 0.68181,-5.33052 0.68181,-8.05776 0,-6.69414 -2.66526,-9.97922 -7.87181,-9.97922 z m -0.55785,4.40077 c 2.66526,0 3.47104,1.67354 3.53302,6.13629 0,1.17768 -0.062,2.60328 -0.30991,3.71897 -2.1694,0.61983 -6.01233,0.74379 -8.36767,0.68181 0.37189,-8.36767 2.60327,-10.53707 5.14456,-10.53707 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1370"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 260.74906,981.09719 c 0.43388,1.73552 1.05371,3.03716 2.23138,3.03716 0.80578,0 2.60328,0 3.53302,-0.18595 l 7.12802,-31.17733 c -5.08259,0 -5.14457,0 -5.33052,1.11569 l -1.67353,8.73957 c -1.23966,6.50819 -2.29337,15.74362 -2.29337,15.74362 h -0.12396 c 0,0 -1.11569,-9.23543 -2.41733,-15.68164 l -1.98345,-9.91724 c -5.51646,0 -5.70241,0 -5.3925,1.54957 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1372"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 286.0574,952.15125 c -5.45448,0 -10.97095,2.23138 -10.97095,17.72706 0,12.08664 4.15285,14.50397 9.91724,14.50397 4.64871,0 8.55362,-1.48759 8.55362,-3.40905 0,-0.99173 -0.12396,-2.47931 -0.43388,-3.40905 -2.10741,1.17767 -4.58672,1.92146 -7.06603,1.92146 -3.78095,0 -5.51647,-1.73552 -5.7644,-8.30569 2.97517,0 8.67759,-0.18595 12.9544,-0.99172 0.49586,-2.23138 0.68181,-5.33052 0.68181,-8.05776 0,-6.69414 -2.66526,-9.97922 -7.87181,-9.97922 z m -0.55785,4.40077 c 2.66526,0 3.47104,1.67354 3.53302,6.13629 0,1.17768 -0.062,2.60328 -0.30991,3.71897 -2.1694,0.61983 -6.01233,0.74379 -8.36768,0.68181 0.3719,-8.36767 2.60328,-10.53707 5.14457,-10.53707 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1374"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 303.43291,938.20513 c -4.02888,0 -5.0206,0 -5.0206,2.29336 v 43.26396 c 5.0206,0 5.0206,0 5.0206,-0.99172 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1376"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 307.82301,968.26676 c 0,13.94612 3.34707,16.11552 9.73129,16.11552 6.63216,0 10.16518,-4.77267 10.16518,-16.30147 0,-12.58249 -3.09914,-15.92956 -9.60733,-15.92956 -6.50819,0 -10.28914,4.77267 -10.28914,16.11551 z m 5.45448,0.12397 c 0,-9.66931 1.92147,-11.83871 4.64871,-11.83871 2.91319,0 4.33879,1.73552 4.33879,11.59078 0,9.66931 -1.92146,11.96267 -4.58672,11.96267 -2.85121,0 -4.40078,-1.48759 -4.40078,-11.71474 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1378"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 331.94594,993.80366 c 0,1.67353 0.68181,2.16939 2.41733,2.16939 0.80577,0 1.7975,-0.12396 2.60327,-0.43388 v -12.89241 c 0.92974,0.92974 2.60328,1.73552 4.89664,1.73552 4.21483,0 9.23543,-2.66526 9.23543,-19.33862 0,-10.16517 -3.96689,-12.89241 -10.10319,-12.89241 -3.34707,0 -6.50819,0.86776 -9.04948,2.47931 z m 5.0206,-36.07397 c 1.05371,-0.74379 2.29337,-1.17767 3.78095,-1.17767 3.16112,0 4.77267,1.67354 4.77267,9.04948 0,12.89242 -3.28508,14.25604 -5.20655,14.25604 -1.23965,0 -2.47931,-0.61983 -3.34707,-2.04543 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1380"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 365.7149,952.15125 c -5.45448,0 -10.97095,2.23138 -10.97095,17.72706 0,12.08664 4.15285,14.50397 9.91724,14.50397 4.64871,0 8.55362,-1.48759 8.55362,-3.40905 0,-0.99173 -0.12396,-2.47931 -0.43388,-3.40905 -2.10741,1.17767 -4.58672,1.92146 -7.06603,1.92146 -3.78095,0 -5.51647,-1.73552 -5.7644,-8.30569 2.97518,0 8.67759,-0.18595 12.9544,-0.99172 0.49586,-2.23138 0.68181,-5.33052 0.68181,-8.05776 0,-6.69414 -2.66526,-9.97922 -7.87181,-9.97922 z m -0.55785,4.40077 c 2.66526,0 3.47104,1.67354 3.53302,6.13629 0,1.17768 -0.062,2.60328 -0.30991,3.71897 -2.1694,0.61983 -6.01233,0.74379 -8.36767,0.68181 0.37189,-8.36767 2.60327,-10.53707 5.14456,-10.53707 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1382"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 378.00783,983.76245 c 5.0206,0 5.08258,0 5.08258,-0.99172 l 0.062,-24.35923 c 1.17767,-0.99172 2.72724,-1.4256 4.09086,-1.4256 1.05371,0 2.04543,0.24793 2.97517,0.74379 0.43388,-1.0537 0.55785,-2.29336 0.55785,-2.97517 0,-1.67353 -1.17768,-2.60327 -4.3388,-2.60327 -3.03715,0 -6.01232,1.11569 -8.42965,2.78922 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1384"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 415.3786,939.56875 c -5.51647,0 -12.21061,3.09914 -12.21061,24.29724 0,18.03698 4.40078,20.70224 10.28914,20.70224 4.58672,0 7.68586,-2.04543 7.68586,-4.46276 0,-1.05371 -0.37189,-2.23138 -0.74379,-3.03716 -1.11569,0.92975 -3.34707,1.92147 -5.70241,1.92147 -3.65699,0 -6.19828,-2.78922 -6.19828,-15.37172 0,-16.36345 3.9669,-19.15267 7.87181,-19.15267 1.92147,0 3.40905,0.99172 4.02888,1.54956 0.43388,-0.74379 0.80578,-1.85948 0.80578,-3.03715 0,-1.61155 -1.23966,-3.40905 -5.82638,-3.40905 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1386"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 422.83009,968.26676 c 0,13.94612 3.34707,16.11552 9.73129,16.11552 6.63216,0 10.16518,-4.77267 10.16518,-16.30147 0,-12.58249 -3.09914,-15.92956 -9.60733,-15.92956 -6.50819,0 -10.28914,4.77267 -10.28914,16.11551 z m 5.45448,0.12397 c 0,-9.66931 1.92147,-11.83871 4.64871,-11.83871 2.91319,0 4.33879,1.73552 4.33879,11.59078 0,9.66931 -1.92146,11.96267 -4.58672,11.96267 -2.85121,0 -4.40078,-1.48759 -4.40078,-11.71474 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1388"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 446.89101,983.76245 c 4.89663,0 5.0206,0 5.0206,-0.99172 v -25.10302 c 1.36362,-0.74379 3.28509,-1.11569 4.58672,-1.11569 3.09914,0 3.71897,1.48759 3.71897,5.3925 v 21.81793 c 5.08259,0 5.20655,0 5.20655,-0.99172 v -22.31379 c 0,-6.01233 -2.23138,-8.30569 -8.73957,-8.30569 -3.28508,0 -7.37595,1.0537 -9.79327,2.10741 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1390"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 472.85017,957.04788 v 26.71457 h 4.02888 c 0.92974,0 0.99172,-0.86776 0.99172,-0.99172 v -25.72285 h 4.52474 c 0.99173,0 1.05371,-0.30991 1.05371,-4.27681 h -5.57845 v -4.15284 c 0,-5.33052 2.97517,-6.07431 6.19828,-6.07431 1.36362,0 2.91319,0.12397 4.40077,0.74379 0.3719,-0.86776 0.55785,-1.92146 0.55785,-2.78922 0,-1.54957 -1.98345,-2.54129 -5.7644,-2.54129 -4.71069,0 -10.4131,1.48758 -10.4131,11.09491 v 3.71896 H 469.875 c -1.30164,0 -1.30164,0.30992 -1.30164,4.27681 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1392"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 495.37023,952.15125 c -5.45448,0 -10.97094,2.23138 -10.97094,17.72706 0,12.08664 4.15284,14.50397 9.91724,14.50397 4.6487,0 8.55362,-1.48759 8.55362,-3.40905 0,-0.99173 -0.12397,-2.47931 -0.43388,-3.40905 -2.10742,1.17767 -4.58673,1.92146 -7.06604,1.92146 -3.78094,0 -5.51646,-1.73552 -5.76439,-8.30569 2.97517,0 8.67758,-0.18595 12.95439,-0.99172 0.49587,-2.23138 0.68181,-5.33052 0.68181,-8.05776 0,-6.69414 -2.66525,-9.97922 -7.87181,-9.97922 z m -0.55784,4.40077 c 2.66526,0 3.47103,1.67354 3.53302,6.13629 0,1.17768 -0.062,2.60328 -0.30992,3.71897 -2.16939,0.61983 -6.01232,0.74379 -8.36767,0.68181 0.3719,-8.36767 2.60328,-10.53707 5.14457,-10.53707 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1394"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 507.66316,983.76245 c 5.02061,0 5.08259,0 5.08259,-0.99172 l 0.062,-24.35923 c 1.17767,-0.99172 2.72724,-1.4256 4.09086,-1.4256 1.05371,0 2.04543,0.24793 2.97518,0.74379 0.43387,-1.0537 0.55784,-2.29336 0.55784,-2.97517 0,-1.67353 -1.17767,-2.60327 -4.33879,-2.60327 -3.03716,0 -6.01233,1.11569 -8.42966,2.78922 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1396"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 532.7778,952.15125 c -5.45449,0 -10.97095,2.23138 -10.97095,17.72706 0,12.08664 4.15284,14.50397 9.91724,14.50397 4.64871,0 8.55362,-1.48759 8.55362,-3.40905 0,-0.99173 -0.12397,-2.47931 -0.43388,-3.40905 -2.10741,1.17767 -4.58672,1.92146 -7.06603,1.92146 -3.78095,0 -5.51647,-1.73552 -5.7644,-8.30569 2.97517,0 8.67759,-0.18595 12.9544,-0.99172 0.49586,-2.23138 0.68181,-5.33052 0.68181,-8.05776 0,-6.69414 -2.66526,-9.97922 -7.87181,-9.97922 z m -0.55785,4.40077 c 2.66526,0 3.47104,1.67354 3.53302,6.13629 0,1.17768 -0.062,2.60328 -0.30992,3.71897 -2.16939,0.61983 -6.01232,0.74379 -8.36767,0.68181 0.3719,-8.36767 2.60328,-10.53707 5.14457,-10.53707 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1398"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 545.07076,983.76245 c 4.89663,0 5.0206,0 5.0206,-0.99172 v -25.10302 c 1.36362,-0.74379 3.28508,-1.11569 4.58672,-1.11569 3.09914,0 3.71897,1.48759 3.71897,5.3925 v 21.81793 c 5.08258,0 5.20655,0 5.20655,-0.99172 v -22.31379 c 0,-6.01233 -2.23138,-8.30569 -8.73957,-8.30569 -3.28508,0 -7.37595,1.0537 -9.79327,2.10741 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1400"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 584.23218,954.94047 c 0,-1.61155 -2.29336,-2.78922 -5.14456,-2.78922 -5.14457,0 -11.1569,1.92146 -11.1569,16.79732 0,13.07836 3.34707,15.43371 9.23543,15.43371 4.09086,0 6.94207,-1.48759 6.94207,-3.16112 0,-0.80578 -0.18595,-1.61155 -0.49586,-2.72724 -1.05371,0.68181 -2.91319,1.4256 -4.89664,1.4256 -3.78095,0 -5.51647,-2.23138 -5.51647,-10.97095 0,-11.03293 3.22311,-12.33456 6.1363,-12.33456 1.67353,0 3.34706,0.55784 4.33879,1.11568 0.43388,-1.0537 0.55784,-2.10741 0.55784,-2.78922 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1402"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 597.30285,952.15125 c -5.45448,0 -10.97095,2.23138 -10.97095,17.72706 0,12.08664 4.15285,14.50397 9.91724,14.50397 4.64871,0 8.55362,-1.48759 8.55362,-3.40905 0,-0.99173 -0.12396,-2.47931 -0.43388,-3.40905 -2.10741,1.17767 -4.58672,1.92146 -7.06603,1.92146 -3.78095,0 -5.51646,-1.73552 -5.7644,-8.30569 2.97518,0 8.67759,-0.18595 12.9544,-0.99172 0.49586,-2.23138 0.68181,-5.33052 0.68181,-8.05776 0,-6.69414 -2.66526,-9.97922 -7.87181,-9.97922 z m -0.55784,4.40077 c 2.66525,0 3.47103,1.67354 3.53301,6.13629 0,1.17768 -0.062,2.60328 -0.30991,3.71897 -2.1694,0.61983 -6.01233,0.74379 -8.36767,0.68181 0.37189,-8.36767 2.60327,-10.53707 5.14457,-10.53707 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1404"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 620.14829,953.57685 c 2.04543,-1.23965 5.82638,-2.1694 9.04948,-2.1694 3.47104,0 4.77268,1.67354 4.77268,4.27681 0,6.88009 -8.73957,13.01638 -14.19405,22.12785 -1.17768,2.04543 -1.48759,2.66526 -1.48759,4.40077 0,0.30992 0.062,1.05371 0.18595,1.54957 h 21.01215 c 1.05371,0 1.05371,-1.4256 1.05371,-5.20655 0,0 -3.9669,0.43388 -7.31397,0.43388 h -8.30569 c 6.01233,-9.3594 14.7519,-15.37172 14.7519,-23.98733 0,-5.3925 -2.04543,-8.42965 -9.17345,-8.42965 -6.01232,0 -10.97095,1.7975 -10.97095,3.28508 0,0.86776 0.062,2.41733 0.61983,3.71897 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1406"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 644.19567,965.41556 c 0,12.27258 2.41733,18.90474 10.97095,18.90474 8.6156,0 11.34284,-6.94207 11.34284,-20.39233 0,-11.59077 -3.03715,-17.35517 -11.03293,-17.35517 -7.99577,0 -11.28086,6.57017 -11.28086,18.84276 z m 5.3925,0.37189 c 0,-9.23543 1.4256,-14.75189 6.13629,-14.75189 4.27681,0 5.51647,4.40077 5.51647,12.83043 0,11.15689 -1.73552,15.86758 -5.95035,15.86758 -4.27681,0 -5.70241,-3.71896 -5.70241,-13.94612 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1408"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 672.58184,952.89504 c 0,0 5.0206,-1.05371 7.06603,-1.11569 l -0.68181,27.21043 c -3.78094,0 -8.92551,0.24793 -8.92551,1.30164 0,0.99172 0.062,2.47931 0.12396,3.47103 h 21.1981 c 1.05371,0 1.05371,-1.54957 1.05371,-4.95862 0,0 -1.67353,0.18595 -3.595,0.18595 h -4.58672 l 0.80577,-32.10707 c -0.24793,-0.18595 -0.92974,-0.30991 -1.4256,-0.30991 -2.10741,0 -11.77672,2.10741 -11.77672,3.03715 0,1.23966 0.30991,2.41733 0.74379,3.28509 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1410"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 702.14568,985.374 c -1.54957,0 -3.03715,-0.18595 -4.52474,-0.61982 -0.18595,0.86775 -0.43388,2.41732 -0.43388,3.40905 0,1.48758 2.5413,2.04543 5.57845,2.04543 10.72302,0 15.43371,-7.99578 15.55767,-24.85509 -0.24793,-14.44198 -1.7975,-19.33862 -10.66103,-19.33862 -7.74785,0 -11.77672,4.95862 -11.77672,15.55768 0,8.11974 3.90491,12.45853 9.04948,12.45853 3.96689,0 6.4462,-1.48759 8.36767,-4.33879 -0.61983,9.17344 -3.2231,15.68163 -11.1569,15.68163 z m 4.27681,-15.99155 c -3.40905,0 -5.57844,-2.97517 -5.57844,-8.42965 0,-7.00405 2.66525,-10.47509 6.88008,-10.47509 4.89664,0 5.7644,4.83466 5.7644,14.07009 v 0.37189 c -2.04543,3.09914 -4.46276,4.46276 -7.06604,4.46276 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1412"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 722.78401,980.3534 c 0,1.36362 0.3719,2.41733 1.4256,3.03715 -0.12396,1.7975 -0.30991,2.91319 -1.73551,5.33052 0.24793,1.05371 1.0537,1.4256 1.98344,1.4256 1.11569,0 4.89664,-4.77267 4.89664,-9.29741 0,-2.54129 -1.23965,-3.71896 -3.40905,-3.71896 -1.85948,0 -3.16112,1.4256 -3.16112,3.2231 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1414"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 744.84019,953.57685 c 2.04543,-1.23965 5.82638,-2.1694 9.04948,-2.1694 3.47103,0 4.77267,1.67354 4.77267,4.27681 0,6.88009 -8.73957,13.01638 -14.19405,22.12785 -1.17767,2.04543 -1.48759,2.66526 -1.48759,4.40077 0,0.30992 0.062,1.05371 0.18595,1.54957 h 21.01216 c 1.0537,0 1.0537,-1.4256 1.0537,-5.20655 0,0 -3.96689,0.43388 -7.31396,0.43388 h -8.30569 c 6.01233,-9.3594 14.75189,-15.37172 14.75189,-23.98733 0,-5.3925 -2.04543,-8.42965 -9.17344,-8.42965 -6.01233,0 -10.97095,1.7975 -10.97095,3.28508 0,0.86776 0.062,2.41733 0.61983,3.71897 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1416"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 783.51549,945.02323 c 2.29337,0 4.27681,0.3719 5.82638,0.92974 0.3719,-1.17767 0.49587,-2.60327 0.49587,-3.595 0,-1.61155 -3.28509,-2.10741 -6.75612,-2.10741 -7.99578,0 -14.07009,5.95034 -14.07009,24.4212 0,11.96267 0.99172,19.58655 10.53707,19.58655 7.74784,0 11.77672,-5.08258 11.77672,-15.68163 0,-8.61561 -3.71896,-12.02466 -8.9875,-12.02466 -3.96689,0 -6.63215,1.48759 -8.49164,4.46276 0.43388,-11.46681 4.15285,-15.99155 9.66931,-15.99155 z m -2.66525,16.1775 c 3.595,0 5.51646,2.97517 5.51646,8.42965 0,5.7644 -2.29336,10.16517 -6.57017,10.16517 -4.15285,0 -6.13629,-3.96689 -5.95035,-13.6362 v -0.3719 c 1.98345,-3.09914 4.27681,-4.58672 7.00406,-4.58672 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1418"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 806.88106,968.51469 c 1.05371,0 1.05371,-1.30163 1.05371,-4.40077 h -11.65276 c -0.99172,0 -0.99172,1.23965 -0.99172,4.40077 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1420"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 813.8444,953.57685 c 2.04543,-1.23965 5.82638,-2.1694 9.04948,-2.1694 3.47103,0 4.77267,1.67354 4.77267,4.27681 0,6.88009 -8.73957,13.01638 -14.19405,22.12785 -1.17767,2.04543 -1.48758,2.66526 -1.48758,4.40077 0,0.30992 0.062,1.05371 0.18594,1.54957 h 21.01216 c 1.0537,0 1.0537,-1.4256 1.0537,-5.20655 0,0 -3.96689,0.43388 -7.31396,0.43388 h -8.30569 c 6.01233,-9.3594 14.7519,-15.37172 14.7519,-23.98733 0,-5.3925 -2.04544,-8.42965 -9.17345,-8.42965 -6.01233,0 -10.97095,1.7975 -10.97095,3.28508 0,0.86776 0.062,2.41733 0.61983,3.71897 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1422"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 844.02807,985.374 c -1.54957,0 -3.03716,-0.18595 -4.52474,-0.61982 -0.18595,0.86775 -0.43388,2.41732 -0.43388,3.40905 0,1.48758 2.54129,2.04543 5.57845,2.04543 10.72301,0 15.4337,-7.99578 15.55767,-24.85509 -0.24793,-14.44198 -1.7975,-19.33862 -10.66104,-19.33862 -7.74784,0 -11.77672,4.95862 -11.77672,15.55768 0,8.11974 3.90491,12.45853 9.04948,12.45853 3.9669,0 6.44621,-1.48759 8.36767,-4.33879 -0.61982,9.17344 -3.2231,15.68163 -11.15689,15.68163 z m 4.27681,-15.99155 c -3.40905,0 -5.57845,-2.97517 -5.57845,-8.42965 0,-7.00405 2.66526,-10.47509 6.88009,-10.47509 4.89663,0 5.76439,4.83466 5.76439,14.07009 v 0.37189 c -2.04543,3.09914 -4.46276,4.46276 -7.06603,4.46276 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1424"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 893.25595,983.76245 c 1.23965,0.12397 2.23138,0.12397 2.97517,0.12397 1.98345,0 2.29336,-0.3719 2.1694,-1.05371 L 887.3056,940.37452 c -0.61982,-0.12396 -1.48758,-0.18594 -2.35534,-0.18594 -1.11569,0 -1.7975,0.24793 -1.92147,0.86775 l -11.03293,42.64414 c 1.17768,0.12396 2.47931,0.18595 3.16113,0.18595 1.98344,0 2.16939,-0.30992 2.35534,-0.99173 l 2.41733,-10.16517 h 10.66103 z m -10.16517,-24.4212 c 0.92974,-4.15285 1.7975,-8.92552 2.16939,-11.90069 0.30992,2.97517 1.17768,7.80982 2.1694,11.90069 l 2.10741,8.80155 h -8.55362 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1426"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 901.65459,993.80366 c 0,1.67353 0.68181,2.16939 2.41733,2.16939 0.80577,0 1.7975,-0.12396 2.60327,-0.43388 v -12.89241 c 0.92974,0.92974 2.60328,1.73552 4.89664,1.73552 4.21483,0 9.23543,-2.66526 9.23543,-19.33862 0,-10.16517 -3.9669,-12.89241 -10.10319,-12.89241 -3.34707,0 -6.50819,0.86776 -9.04948,2.47931 z m 5.0206,-36.07397 c 1.05371,-0.74379 2.29336,-1.17767 3.78095,-1.17767 3.16112,0 4.77267,1.67354 4.77267,9.04948 0,12.89242 -3.28508,14.25604 -5.20655,14.25604 -1.23965,0 -2.47931,-0.61983 -3.34707,-2.04543 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1428"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 925.32039,983.76245 c 5.0206,0 5.08259,0 5.08259,-0.99172 l 0.062,-24.35923 c 1.17767,-0.99172 2.72724,-1.4256 4.09086,-1.4256 1.05371,0 2.04543,0.24793 2.97517,0.74379 0.43388,-1.0537 0.55785,-2.29336 0.55785,-2.97517 0,-1.67353 -1.17768,-2.60327 -4.3388,-2.60327 -3.03715,0 -6.01232,1.11569 -8.42965,2.78922 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1430"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 946.87008,952.77107 c -4.09086,0 -5.14457,0 -5.14457,2.29337 v 28.69801 c 5.08259,0 5.14457,0 5.14457,-0.99172 z m -5.08259,-9.85525 c 0,2.91319 0.92975,3.90491 2.5413,3.90491 1.92146,0 2.8512,-1.48759 2.8512,-4.02888 0.062,-2.60327 -0.55784,-3.595 -2.47931,-3.595 -1.98344,0 -2.8512,1.48759 -2.91319,3.71897 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1432"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 957.6415,938.20513 c -4.02888,0 -5.0206,0 -5.0206,2.29336 v 43.26396 c 5.0206,0 5.0206,0 5.0206,-0.99172 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1434"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 973.88584,953.57685 c 2.04543,-1.23965 5.82638,-2.1694 9.04948,-2.1694 3.47104,0 4.77268,1.67354 4.77268,4.27681 0,6.88009 -8.73957,13.01638 -14.19406,22.12785 -1.17767,2.04543 -1.48758,2.66526 -1.48758,4.40077 0,0.30992 0.062,1.05371 0.18595,1.54957 h 21.01215 c 1.05371,0 1.05371,-1.4256 1.05371,-5.20655 0,0 -3.9669,0.43388 -7.31397,0.43388 h -8.30569 c 6.01233,-9.3594 14.7519,-15.37172 14.7519,-23.98733 0,-5.3925 -2.04543,-8.42965 -9.17345,-8.42965 -6.01233,0 -10.97095,1.7975 -10.97095,3.28508 0,0.86776 0.062,2.41733 0.61983,3.71897 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1436"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 997.93322,965.41556 c 0,12.27258 2.41728,18.90474 10.97098,18.90474 8.6156,0 11.3428,-6.94207 11.3428,-20.39233 0,-11.59077 -3.0371,-17.35517 -11.0329,-17.35517 -7.9958,0 -11.28088,6.57017 -11.28088,18.84276 z m 5.39248,0.37189 c 0,-9.23543 1.4256,-14.75189 6.1363,-14.75189 4.2768,0 5.5165,4.40077 5.5165,12.83043 0,11.15689 -1.7355,15.86758 -5.9504,15.86758 -4.2768,0 -5.7024,-3.71896 -5.7024,-13.94612 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1438"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 1026.3194,952.89504 c 0,0 5.0206,-1.05371 7.066,-1.11569 l -0.6818,27.21043 c -3.7809,0 -8.9255,0.24793 -8.9255,1.30164 0,0.99172 0.062,2.47931 0.124,3.47103 h 21.1981 c 1.0537,0 1.0537,-1.54957 1.0537,-4.95862 0,0 -1.6736,0.18595 -3.595,0.18595 h -4.5868 l 0.8058,-32.10707 c -0.2479,-0.18595 -0.9297,-0.30991 -1.4256,-0.30991 -2.1074,0 -11.7767,2.10741 -11.7767,3.03715 0,1.23966 0.3099,2.41733 0.7438,3.28509 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1440"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 1055.8832,985.374 c -1.5495,0 -3.0371,-0.18595 -4.5247,-0.61982 -0.186,0.86775 -0.4339,2.41732 -0.4339,3.40905 0,1.48758 2.5413,2.04543 5.5785,2.04543 10.723,0 15.4337,-7.99578 15.5576,-24.85509 -0.2479,-14.44198 -1.7975,-19.33862 -10.661,-19.33862 -7.7478,0 -11.7767,4.95862 -11.7767,15.55768 0,8.11974 3.9049,12.45853 9.0495,12.45853 3.9669,0 6.4462,-1.48759 8.3676,-4.33879 -0.6198,9.17344 -3.2231,15.68163 -11.1569,15.68163 z m 4.2768,-15.99155 c -3.409,0 -5.5784,-2.97517 -5.5784,-8.42965 0,-7.00405 2.6653,-10.47509 6.8801,-10.47509 4.8966,0 5.7644,4.83466 5.7644,14.07009 v 0.37189 c -2.0455,3.09914 -4.4628,4.46276 -7.0661,4.46276 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1442"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 1076.5216,980.3534 c 0,1.36362 0.3719,2.41733 1.4256,3.03715 -0.124,1.7975 -0.31,2.91319 -1.7356,5.33052 0.248,1.05371 1.0538,1.4256 1.9835,1.4256 1.1157,0 4.8966,-4.77267 4.8966,-9.29741 0,-2.54129 -1.2396,-3.71896 -3.409,-3.71896 -1.8595,0 -3.1611,1.4256 -3.1611,3.2231 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1444"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 1097.586,983.76245 h 7.8098 c 6.4462,0 11.7768,-4.33879 11.7768,-14.75189 0,-7.43793 -4.4628,-8.86354 -7.314,-9.04949 2.6653,-0.37189 5.9503,-3.16112 5.9503,-9.97922 0,-7.99577 -5.4544,-9.60733 -10.4131,-9.60733 h -6.1363 c -1.3016,0 -1.6735,0.43388 -1.6735,1.17768 z m 5.1446,-38.92517 h 2.9752 c 2.3553,0 4.5867,1.05371 4.5867,6.13629 0,4.89664 -1.9215,7.12802 -4.5248,7.12802 h -3.0371 z m 0,17.6031 h 2.8512 c 3.3471,0 5.7024,0.61983 5.7024,7.00406 0,7.06603 -2.6653,9.91724 -5.7644,9.91724 h -2.7892 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1446"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 1131.1777,952.15125 c -5.4545,0 -10.971,2.23138 -10.971,17.72706 0,12.08664 4.1529,14.50397 9.9173,14.50397 4.6487,0 8.5536,-1.48759 8.5536,-3.40905 0,-0.99173 -0.124,-2.47931 -0.4339,-3.40905 -2.1074,1.17767 -4.5867,1.92146 -7.066,1.92146 -3.781,0 -5.5165,-1.73552 -5.7644,-8.30569 2.9751,0 8.6776,-0.18595 12.9544,-0.99172 0.4958,-2.23138 0.6818,-5.33052 0.6818,-8.05776 0,-6.69414 -2.6653,-9.97922 -7.8718,-9.97922 z m -0.5579,4.40077 c 2.6653,0 3.4711,1.67354 3.533,6.13629 0,1.17768 -0.062,2.60328 -0.3099,3.71897 -2.1694,0.61983 -6.0123,0.74379 -8.3676,0.68181 0.3719,-8.36767 2.6032,-10.53707 5.1445,-10.53707 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1448"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 1143.4706,983.76245 c 5.0206,0 5.0826,0 5.0826,-0.99172 l 0.062,-24.35923 c 1.1776,-0.99172 2.7272,-1.4256 4.0908,-1.4256 1.0537,0 2.0455,0.24793 2.9752,0.74379 0.4339,-1.0537 0.5578,-2.29336 0.5578,-2.97517 0,-1.67353 -1.1776,-2.60327 -4.3387,-2.60327 -3.0372,0 -6.0124,1.11569 -8.4297,2.78922 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1450"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 1164.8963,938.20513 c -4.0289,0 -5.0206,0 -5.0206,2.29336 v 43.26396 c 5.0206,0 5.0206,0 5.0206,-0.99172 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1452"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 1199.6425,983.76245 c 4.8966,0 5.0206,0 5.0206,-0.99172 v -25.10302 c 1.3636,-0.74379 3.2851,-1.11569 4.5867,-1.11569 3.0991,0 3.719,1.48759 3.719,5.3925 v 21.81793 c 5.0826,0 5.2065,0 5.2065,-0.99172 v -22.31379 c 0,-6.01233 -2.2314,-8.30569 -8.7396,-8.30569 -3.285,0 -7.3759,1.0537 -9.7932,2.10741 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+           id="path1454"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         style="display:inline"
+         transform="matrix(4.0085474,0,0,4.0085474,922.49571,483.88119)"
+         id="g27740-6">
+        <g
+           id="g28309-1">
+          <path
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:normal;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.98000004;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6.24451828;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             d="m 3820.6562,472.26172 c -40.3422,0 -73.1445,32.3975 -73.1445,72.32812 0,30.32091 18.9212,56.28015 45.6875,67.02735 l 1.8555,-5.95508 c -24.2644,-9.91834 -41.2988,-33.51066 -41.2988,-61.07227 0,-36.51604 29.8935,-66.08398 66.9003,-66.08398 37.0069,0 66.8985,29.56794 66.8985,66.08398 0,24.66524 -13.6587,46.14338 -33.918,57.50977 -2.3907,1.34129 -4.8745,2.53952 -7.4355,3.58594 l 1.8535,5.96875 c 2.9828,-1.19355 5.8704,-2.56971 8.6426,-4.125 22.1465,-12.42531 37.1035,-35.96788 37.1035,-62.93946 0,-39.93062 -32.8023,-72.32812 -73.1446,-72.32812 z m 7.5,137.99414 c -2.4618,0.2706 -4.962,0.41602 -7.5,0.41602 -2.5028,0 -4.9696,-0.14473 -7.4003,-0.40821 l -1.8633,6.05469 c 3.0363,0.3807 6.1241,0.59767 9.2636,0.59766 3.182,0 6.3161,-0.2044 9.3926,-0.59571 z"
+             id="path3544-2-5"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ssccsssscccsscsccccc"
+             transform="matrix(0.04785074,0,0,0.04785074,-118.05951,92.995687)" />
+          <path
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a00000;stroke-width:6.34386444px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 3811.3887,563.87891 -30.2735,97.13867 h 78.9297 l -30.1523,-97.125 c -2.8017,1.31925 -5.9315,2.05859 -9.2364,2.05859 -3.3169,0 -6.4581,-0.74396 -9.2675,-2.07226 z m 9.2675,11.66406 19.3165,61.84961 h -38.4082 z"
+             transform="matrix(0.04785074,0,0,0.04785074,-118.05951,92.995687)"
+             id="path3548-6-5"
+             inkscape:connector-curvature="0" />
+          <path
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#a00000;stroke-width:0.3038334;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path3556-1-4"
+             d="m 65.796938,119.04618 c 0,0.56924 -0.463484,1.03071 -1.035215,1.03071 -0.571734,0 -1.035215,-0.46147 -1.035215,-1.03071 0,-0.56925 0.463481,-1.03071 1.035215,-1.03071 0.571731,0 1.035215,0.46146 1.035215,1.03071 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <path
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#3465a4;stroke-width:0.29880485;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+           id="path3552-8-7"
+           d="m 66.957088,119.05451 c 0,1.21246 -0.982899,2.19537 -2.195365,2.19537 -1.212466,0 -2.195365,-0.98291 -2.195365,-2.19537 0,-1.21246 0.982899,-2.19537 2.195365,-2.19537 1.212466,0 2.195365,0.98291 2.195365,2.19537 z"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer8"
+       inkscape:label="subtitle_font"
+       style="display:none">
+      <g
+         style="display:inline"
+         id="g1750"
+         transform="matrix(19.592171,0,0,19.592171,-2611.4376,-2143.7586)">
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.16364908px;line-height:100%;font-family:Galette;-inkscape-font-specification:'Galette Bold';letter-spacing:0px;word-spacing:0px;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:0.02372737px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="195.58928"
+           y="159.63116"
+           id="text1124"><tspan
+             sodipodi:role="line"
+             x="195.58928"
+             y="159.63116"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.02372737px"
+             id="tspan1128">Osmocom Developer Conference 2019, 26-29 April 2019, Berl   n</tspan></text>
+        <g
+           transform="matrix(0.20459945,0,0,0.20459945,180.37477,134.11683)"
+           id="g27740">
+          <g
+             id="g28309">
+            <path
+               style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:normal;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.98000004;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6.24451828;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m 3820.6562,472.26172 c -40.3422,0 -73.1445,32.3975 -73.1445,72.32812 0,30.32091 18.9212,56.28015 45.6875,67.02735 l 1.8555,-5.95508 c -24.2644,-9.91834 -41.2988,-33.51066 -41.2988,-61.07227 0,-36.51604 29.8935,-66.08398 66.9003,-66.08398 37.0069,0 66.8985,29.56794 66.8985,66.08398 0,24.66524 -13.6587,46.14338 -33.918,57.50977 -2.3907,1.34129 -4.8745,2.53952 -7.4355,3.58594 l 1.8535,5.96875 c 2.9828,-1.19355 5.8704,-2.56971 8.6426,-4.125 22.1465,-12.42531 37.1035,-35.96788 37.1035,-62.93946 0,-39.93062 -32.8023,-72.32812 -73.1446,-72.32812 z m 7.5,137.99414 c -2.4618,0.2706 -4.962,0.41602 -7.5,0.41602 -2.5028,0 -4.9696,-0.14473 -7.4003,-0.40821 l -1.8633,6.05469 c 3.0363,0.3807 6.1241,0.59767 9.2636,0.59766 3.182,0 6.3161,-0.2044 9.3926,-0.59571 z"
+               id="path3544-2"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="ssccsssscccsscsccccc"
+               transform="matrix(0.04785074,0,0,0.04785074,-118.05951,92.995687)" />
+            <path
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a00000;stroke-width:6.34386444px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               d="m 3811.3887,563.87891 -30.2735,97.13867 h 78.9297 l -30.1523,-97.125 c -2.8017,1.31925 -5.9315,2.05859 -9.2364,2.05859 -3.3169,0 -6.4581,-0.74396 -9.2675,-2.07226 z m 9.2675,11.66406 19.3165,61.84961 h -38.4082 z"
+               transform="matrix(0.04785074,0,0,0.04785074,-118.05951,92.995687)"
+               id="path3548-6"
+               inkscape:connector-curvature="0" />
+            <path
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#a00000;stroke-width:0.3038334;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               id="path3556-1"
+               d="m 65.796938,119.04618 c 0,0.56924 -0.463484,1.03071 -1.035215,1.03071 -0.571734,0 -1.035215,-0.46147 -1.035215,-1.03071 0,-0.56925 0.463481,-1.03071 1.035215,-1.03071 0.571731,0 1.035215,0.46146 1.035215,1.03071 z"
+               inkscape:connector-curvature="0" />
+          </g>
+          <path
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#3465a4;stroke-width:0.29880485;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+             id="path3552-8"
+             d="m 66.957088,119.05451 c 0,1.21246 -0.982899,2.19537 -2.195365,2.19537 -1.212466,0 -2.195365,-0.98291 -2.195365,-2.19537 0,-1.21246 0.982899,-2.19537 2.195365,-2.19537 1.212466,0 2.195365,0.98291 2.195365,2.19537 z"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/osmodevcon2019/artwork/outro.svg
+++ b/osmodevcon2019/artwork/outro.svg
@@ -1,0 +1,1479 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1920"
+   height="1080"
+   viewBox="0 0 1800 1012.5"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"
+   sodipodi:docname="outro.svg"
+   inkscape:export-filename="outro.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3374-5-7-7-0">
+      <stop
+         id="stop3376-8-6-4-2"
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3378-6-7-4-9"
+         style="stop-color:#729fcf;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3362-8-6-0-9">
+      <stop
+         id="stop3364-4-5-78-9"
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3366-7-6-6-4"
+         style="stop-color:#3465a4;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.837126"
+       y1="44.528019"
+       x2="21.036427"
+       y2="21.041553"
+       id="linearGradient3991-3-88-5"
+       xlink:href="#linearGradient7101-4-9-4-1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient7101-4-9-4-1">
+      <stop
+         id="stop7103-0-4-31-0"
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7105-6-8-4-3"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="39.06765"
+       y1="28.5"
+       x2="39.421204"
+       y2="10.934953"
+       id="linearGradient3993-1-9-7"
+       xlink:href="#linearGradient6979-9-2-2-8"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient6979-9-2-2-8">
+      <stop
+         id="stop6981-9-9-0-8"
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6983-0-3-6-6"
+         style="stop-color:#555753;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <linearGradient
+       id="linearGradient7131-6-1-5-7">
+      <stop
+         id="stop7133-4-5-2-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7135-6-9-5-0"
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <linearGradient
+       id="linearGradient7153-0-1-9-75">
+      <stop
+         id="stop7155-8-7-3-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7157-5-7-7-7"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.837126"
+       y1="44.528019"
+       x2="21.036427"
+       y2="21.041553"
+       id="linearGradient3991-3-88-5-3"
+       xlink:href="#linearGradient7101-4-9-4-1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="39.06765"
+       y1="28.5"
+       x2="39.421204"
+       y2="10.934953"
+       id="linearGradient3993-1-9-7-2"
+       xlink:href="#linearGradient6979-9-2-2-8"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <linearGradient
+       x1="24.837126"
+       y1="44.528019"
+       x2="21.036427"
+       y2="21.041553"
+       id="linearGradient3991-3-88-5-3-4"
+       xlink:href="#linearGradient7101-4-9-4-1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="39.06765"
+       y1="28.5"
+       x2="39.421204"
+       y2="10.934953"
+       id="linearGradient3993-1-9-7-2-4"
+       xlink:href="#linearGradient6979-9-2-2-8"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-3"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-1"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-7"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-6"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <linearGradient
+       x1="24.837126"
+       y1="44.528019"
+       x2="21.036427"
+       y2="21.041553"
+       id="linearGradient3991-3-88-5-3-5"
+       xlink:href="#linearGradient7101-4-9-4-1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="39.06765"
+       y1="28.5"
+       x2="39.421204"
+       y2="10.934953"
+       id="linearGradient3993-1-9-7-2-0"
+       xlink:href="#linearGradient6979-9-2-2-8"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-0"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-6"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-4"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-5"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-02"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-3"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-75"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-2"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9-7"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1-9"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2-2"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9-3"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9-7-1"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1-9-9"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2-2-4"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9-3-4"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9-20"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1-2"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2-3"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9-9"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       r="4.5250292"
+       fy="8.0709476"
+       fx="10.28125"
+       cy="8.0709476"
+       cx="10.28125"
+       gradientTransform="matrix(4.9499444,0,0,4.9510321,-11.38809,35.312197)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3637-3-3"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       inkscape:collect="always" />
+    <radialGradient
+       r="4.5250292"
+       fy="9.8424416"
+       fx="10.28125"
+       cy="9.8424416"
+       cx="10.28125"
+       gradientTransform="matrix(23.169932,0,0,7.6402677,-198.71238,8.843597)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3639-5-5"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       inkscape:collect="always" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9-0"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1-9-91"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2-36"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9-2"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.35"
+     inkscape:cx="1351.3734"
+     inkscape:cy="461.35657"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1080"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:measure-start="63.3968,-113.628"
+     inkscape:measure-end="34.3452,-129.3"
+     inkscape:snap-page="true"
+     inkscape:pagecheckerboard="true"
+     gridtolerance="5"
+     objecttolerance="10"
+     guidetolerance="10"
+     inkscape:lockguides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid20483" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     transform="translate(0,-67.5)"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <rect
+       style="opacity:1;fill:#fffff3;fill-opacity:1;stroke:none;stroke-width:1.00031257;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect20497"
+       width="1800"
+       height="1012.4999"
+       x="0"
+       y="67.5"
+       inkscape:label="bg color" />
+    <rect
+       style="display:inline;opacity:1;fill:#7ba4d9;fill-opacity:1;stroke:none;stroke-width:0.96588516;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect20265"
+       width="1800"
+       height="339.50528"
+       x="1.1368684e-13"
+       y="740.49463"
+       inkscape:label="Bande Blau Unten" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Text"
+     style="display:inline"
+     transform="translate(0,-67.5)">
+    <flowRoot
+       xml:space="preserve"
+       id="title"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;opacity:0;fill:#555555;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       transform="matrix(0.9375,0,0,0.9375,596.82417,403.33401)"
+       inkscape:label="title"
+       inkscape:transform-center-x="4.0178571"
+       inkscape:transform-center-y="-24.107143"><flowRegion
+         id="flowRegion20435"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1"><rect
+           id="rect20437"
+           width="604.28571"
+           height="189.99998"
+           x="61.42857"
+           y="67.714287"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1" /></flowRegion><flowPara
+         id="flowPara24792"
+         style="font-size:192px">Pause</flowPara></flowRoot>    <flowRoot
+       xml:space="preserve"
+       id="flowRoot25337"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"><flowRegion
+         id="flowRegion25339"><rect
+           id="rect25341"
+           width="14.285714"
+           height="90"
+           x="902.85712"
+           y="472.85715" /></flowRegion><flowPara
+         id="flowPara25343" /></flowRoot>    <flowRoot
+       inkscape:transform-center-y="-24.107143"
+       inkscape:transform-center-x="4.0178571"
+       inkscape:label="title"
+       transform="matrix(0.9375,0,0,0.9375,604.85988,449.04839)"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;opacity:0;fill:#555555;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="pause"
+       xml:space="preserve"><flowRegion
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1"
+         id="flowRegion25395"><rect
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1"
+           y="67.714287"
+           x="61.42857"
+           height="189.99998"
+           width="604.28571"
+           id="rect25393" /></flowRegion><flowPara
+         style="font-size:192px"
+         id="flowPara25397">Pause</flowPara></flowRoot>    <g
+       aria-label="Pause"
+       transform="matrix(0.9375,0,0,0.9375,596.82416,403.33401)"
+       inkscape:transform-center-x="4.0178571"
+       inkscape:transform-center-y="-24.107143"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0;fill:#555555;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="title-3">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 79.052734,2.6210928 h 59.906246 q 26.71875,0 40.96875,11.9062502 14.34375,11.8125 14.34375,33.75 0,22.03125 -14.34375,33.9375 -14.25,11.8125 -40.96875,11.8125 h -23.8125 V 142.58984 H 79.052734 Z M 115.14648,28.777343 v 39.09375 h 19.96875 q 10.5,0 16.21875,-5.0625 5.71875,-5.15625 5.71875,-14.53125 0,-9.375 -5.71875,-14.4375 -5.71875,-5.0625 -16.21875,-5.0625 z"
+         style="font-size:192px"
+         id="path1727" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 259.99023,95.339843 q -10.5,0 -15.84375,3.5625 -5.25,3.562497 -5.25,10.499997 0,6.375 4.21875,10.03125 4.3125,3.5625 11.90625,3.5625 9.46875,0 15.9375,-6.75 6.46875,-6.84375 6.46875,-17.062497 v -3.84375 z m 51.28125,-12.65625 v 59.906247 h -33.84375 v -15.5625 q -6.75,9.5625 -15.1875,13.96875 -8.4375,4.3125 -20.53125,4.3125 -16.3125,0 -26.53125,-9.46875 -10.125,-9.5625 -10.125,-24.75 0,-18.468747 12.65625,-27.093747 12.75,-8.625 39.9375,-8.625 h 19.78125 v -2.625 q 0,-7.96875 -6.28125,-11.625 -6.28125,-3.75 -19.59375,-3.75 -10.78125,0 -20.0625,2.15625 -9.28125,2.15625 -17.25,6.46875 v -25.59375 q 10.78125,-2.625 21.65625,-3.9375 10.875,-1.40625 21.75,-1.40625 28.40625,0 40.96875,11.25 12.65625,11.15625 12.65625,36.375 z"
+         style="font-size:192px"
+         id="path1729" />
+      <path
+         inkscape:connector-curvature="0"
+         d="M 341.55273,101.71484 V 37.589843 h 33.75 v 10.5 q 0,8.53125 -0.0937,21.46875 -0.0937,12.84375 -0.0937,17.15625 0,12.65625 0.65625,18.281247 0.65625,5.53125 2.25,8.0625 2.0625,3.28125 5.34375,5.0625 3.375,1.78125 7.6875,1.78125 10.5,0 16.5,-8.0625 6,-8.0625 6,-22.406247 v -51.84375 h 33.5625 V 142.58984 h -33.5625 v -15.1875 q -7.59375,9.1875 -16.125,13.59375 -8.4375,4.3125 -18.65625,4.3125 -18.1875,0 -27.75,-11.15625 -9.46875,-11.15625 -9.46875,-32.4375 z"
+         style="font-size:192px"
+         id="path1731" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 561.58398,40.871093 v 25.5 q -10.78125,-4.5 -20.8125,-6.75 -10.03125,-2.25 -18.9375,-2.25 -9.5625,0 -14.25,2.4375 -4.59375,2.34375 -4.59375,7.3125 0,4.03125 3.46875,6.1875 3.5625,2.15625 12.65625,3.1875 l 5.90625,0.84375 q 25.78125,3.28125 34.6875,10.78125 8.90625,7.5 8.90625,23.531247 0,16.78125 -12.375,25.21875 -12.375,8.4375 -36.9375,8.4375 -10.40625,0 -21.5625,-1.6875 -11.0625,-1.59375 -22.78125,-4.875 v -25.5 q 10.03125,4.875 20.53125,7.3125 10.59375,2.4375 21.46875,2.4375 9.84375,0 14.8125,-2.71875 4.96875,-2.71875 4.96875,-8.0625 0,-4.5 -3.46875,-6.65625 -3.375,-2.25 -13.59375,-3.46875 l -5.90625,-0.75 q -22.40625,-2.812497 -31.40625,-10.406247 -9,-7.59375 -9,-23.0625 0,-16.6875 11.4375,-24.75 11.4375,-8.0625 35.0625,-8.0625 9.28125,0 19.5,1.40625 10.21875,1.40625 22.21875,4.40625 z"
+         style="font-size:192px"
+         id="path1733" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 182.36523,179.29297 v 9.5625 h -78.46875 q 1.21875,11.8125 8.53125,17.71875 7.3125,5.90625 20.4375,5.90625 10.59375,0 21.65625,-3.09375 11.15625,-3.1875 22.875,-9.5625 v 25.875 q -11.90625,4.5 -23.8125,6.75 -11.90625,2.34375 -23.8125,2.34375 -28.5,0 -44.343746,-14.4375 -15.75,-14.53125 -15.75,-40.6875 0,-25.6875 15.46875,-40.40625 15.562496,-14.71875 42.749996,-14.71875 24.75,0 39.5625,14.90625 14.90625,14.90625 14.90625,39.84375 z m -34.5,-11.15625 q 0,-9.5625 -5.625,-15.375 -5.53125,-5.90625 -14.53125,-5.90625 -9.75,0 -15.84375,5.53125 -6.09375,5.4375 -7.59375,15.75 z"
+         style="font-size:192px"
+         id="path1735" />
+    </g>
+    <g
+       aria-label="Pause"
+       transform="matrix(0.9375,0,0,0.9375,604.85987,449.04839)"
+       inkscape:transform-center-x="4.0178571"
+       inkscape:transform-center-y="-24.107143"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0;fill:#555555;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="pause-6">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 79.052734,2.6210928 h 59.906246 q 26.71875,0 40.96875,11.9062502 14.34375,11.8125 14.34375,33.75 0,22.03125 -14.34375,33.9375 -14.25,11.8125 -40.96875,11.8125 h -23.8125 V 142.58984 H 79.052734 Z M 115.14648,28.777343 v 39.09375 h 19.96875 q 10.5,0 16.21875,-5.0625 5.71875,-5.15625 5.71875,-14.53125 0,-9.375 -5.71875,-14.4375 -5.71875,-5.0625 -16.21875,-5.0625 z"
+         style="font-size:192px"
+         id="path1738" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 259.99023,95.339843 q -10.5,0 -15.84375,3.5625 -5.25,3.562497 -5.25,10.499997 0,6.375 4.21875,10.03125 4.3125,3.5625 11.90625,3.5625 9.46875,0 15.9375,-6.75 6.46875,-6.84375 6.46875,-17.062497 v -3.84375 z m 51.28125,-12.65625 v 59.906247 h -33.84375 v -15.5625 q -6.75,9.5625 -15.1875,13.96875 -8.4375,4.3125 -20.53125,4.3125 -16.3125,0 -26.53125,-9.46875 -10.125,-9.5625 -10.125,-24.75 0,-18.468747 12.65625,-27.093747 12.75,-8.625 39.9375,-8.625 h 19.78125 v -2.625 q 0,-7.96875 -6.28125,-11.625 -6.28125,-3.75 -19.59375,-3.75 -10.78125,0 -20.0625,2.15625 -9.28125,2.15625 -17.25,6.46875 v -25.59375 q 10.78125,-2.625 21.65625,-3.9375 10.875,-1.40625 21.75,-1.40625 28.40625,0 40.96875,11.25 12.65625,11.15625 12.65625,36.375 z"
+         style="font-size:192px"
+         id="path1740" />
+      <path
+         inkscape:connector-curvature="0"
+         d="M 341.55273,101.71484 V 37.589843 h 33.75 v 10.5 q 0,8.53125 -0.0937,21.46875 -0.0937,12.84375 -0.0937,17.15625 0,12.65625 0.65625,18.281247 0.65625,5.53125 2.25,8.0625 2.0625,3.28125 5.34375,5.0625 3.375,1.78125 7.6875,1.78125 10.5,0 16.5,-8.0625 6,-8.0625 6,-22.406247 v -51.84375 h 33.5625 V 142.58984 h -33.5625 v -15.1875 q -7.59375,9.1875 -16.125,13.59375 -8.4375,4.3125 -18.65625,4.3125 -18.1875,0 -27.75,-11.15625 -9.46875,-11.15625 -9.46875,-32.4375 z"
+         style="font-size:192px"
+         id="path1742" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 561.58398,40.871093 v 25.5 q -10.78125,-4.5 -20.8125,-6.75 -10.03125,-2.25 -18.9375,-2.25 -9.5625,0 -14.25,2.4375 -4.59375,2.34375 -4.59375,7.3125 0,4.03125 3.46875,6.1875 3.5625,2.15625 12.65625,3.1875 l 5.90625,0.84375 q 25.78125,3.28125 34.6875,10.78125 8.90625,7.5 8.90625,23.531247 0,16.78125 -12.375,25.21875 -12.375,8.4375 -36.9375,8.4375 -10.40625,0 -21.5625,-1.6875 -11.0625,-1.59375 -22.78125,-4.875 v -25.5 q 10.03125,4.875 20.53125,7.3125 10.59375,2.4375 21.46875,2.4375 9.84375,0 14.8125,-2.71875 4.96875,-2.71875 4.96875,-8.0625 0,-4.5 -3.46875,-6.65625 -3.375,-2.25 -13.59375,-3.46875 l -5.90625,-0.75 q -22.40625,-2.812497 -31.40625,-10.406247 -9,-7.59375 -9,-23.0625 0,-16.6875 11.4375,-24.75 11.4375,-8.0625 35.0625,-8.0625 9.28125,0 19.5,1.40625 10.21875,1.40625 22.21875,4.40625 z"
+         style="font-size:192px"
+         id="path1744" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 182.36523,179.29297 v 9.5625 h -78.46875 q 1.21875,11.8125 8.53125,17.71875 7.3125,5.90625 20.4375,5.90625 10.59375,0 21.65625,-3.09375 11.15625,-3.1875 22.875,-9.5625 v 25.875 q -11.90625,4.5 -23.8125,6.75 -11.90625,2.34375 -23.8125,2.34375 -28.5,0 -44.343746,-14.4375 -15.75,-14.53125 -15.75,-40.6875 0,-25.6875 15.46875,-40.40625 15.562496,-14.71875 42.749996,-14.71875 24.75,0 39.5625,14.90625 14.90625,14.90625 14.90625,39.84375 z m -34.5,-11.15625 q 0,-9.5625 -5.625,-15.375 -5.53125,-5.90625 -14.53125,-5.90625 -9.75,0 -15.84375,5.53125 -6.09375,5.4375 -7.59375,15.75 z"
+         style="font-size:192px"
+         id="path1746" />
+    </g>
+    <g
+       transform="translate(-3.75e-7,67.5)"
+       aria-label="Osmocom Developer Conference 2019, 26-29 April 2019, Berl   n"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:61.98275375px;line-height:100%;font-family:Galette;-inkscape-font-specification:'Galette Bold';letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:0.46487072px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="text1124-2">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 16.924401,961.82056 c 0,17.85103 3.16112,22.49974 11.156895,22.49974 8.181724,0 11.714741,-5.64043 11.714741,-22.68569 0,-16.73535 -2.975172,-21.81793 -11.03293,-21.81793 -7.995775,0 -11.838706,5.51646 -11.838706,22.00388 z m 5.64043,1.23965 c 0,-13.38827 1.735518,-18.09896 6.07431,-18.09896 4.462759,0 5.702414,4.40077 5.702414,16.79732 0,12.64449 -1.549569,17.41716 -6.012327,17.41716 -4.400776,0 -5.764397,-4.58673 -5.764397,-16.11552 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1354" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 53.601726,952.15125 c -6.942068,0 -10.103189,2.97517 -10.103189,7.31396 0,2.04543 0.743793,4.27681 3.533017,6.57017 l 6.012327,5.14457 c 1.859483,1.67354 2.47931,3.16112 2.47931,4.83466 0,2.47931 -1.859482,3.84293 -5.020603,3.84293 -2.417327,0 -4.400775,-0.49586 -6.198275,-1.54957 -0.68181,1.11569 -0.867759,2.1694 -0.867759,2.91319 0,2.16939 3.161121,3.16112 7.561896,3.16112 6.322241,0 10.227155,-3.09914 10.227155,-8.6156 0,-3.09914 -0.991724,-5.14457 -3.656983,-7.74785 l -5.764396,-4.6487 c -2.107413,-1.73552 -2.47931,-2.72725 -2.47931,-3.84294 0,-1.92146 1.983448,-2.97517 4.896638,-2.97517 2.355344,0 4.214827,0.49586 6.074309,1.61155 0.681811,-0.74379 1.11569,-1.73551 1.11569,-2.54129 0,-1.23965 -1.425603,-3.47103 -7.809827,-3.47103 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1356" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 78.128495,983.76245 c 5.082586,0 5.020603,0 5.020603,-0.99172 v -24.97905 c 1.363621,-0.86776 2.727241,-1.17767 4.152845,-1.17767 2.47931,0 3.037155,1.23965 3.037155,4.21482 v 22.93362 c 4.834654,0 5.020603,0 5.020603,-0.99172 v -21.87991 c 0,-5.57845 -0.743793,-8.73957 -6.942069,-8.73957 -2.541293,0 -5.516465,0.74379 -7.623878,1.92146 -1.177673,-1.23965 -2.91319,-1.92146 -5.578448,-1.92146 -3.409052,0 -6.632155,0.80577 -9.359396,2.04543 v 29.56577 c 4.834655,0 5.020603,0 5.020603,-0.99172 v -25.165 c 1.425603,-0.74379 2.851207,-1.05371 4.214827,-1.05371 2.47931,0 2.975172,0.86776 3.037155,3.09914 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1358" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 99.357589,968.26676 c 0,13.94612 3.347071,16.11552 9.731291,16.11552 6.63216,0 10.16517,-4.77267 10.16517,-16.30147 0,-12.58249 -3.09914,-15.92956 -9.60732,-15.92956 -6.50819,0 -10.289141,4.77267 -10.289141,16.11551 z m 5.454481,0.12397 c 0,-9.66931 1.92147,-11.83871 4.64871,-11.83871 2.91319,0 4.33879,1.73552 4.33879,11.59078 0,9.66931 -1.92147,11.96267 -4.58672,11.96267 -2.85121,0 -4.40078,-1.48759 -4.40078,-11.71474 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1360" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 138.85222,954.94047 c 0,-1.61155 -2.29336,-2.78922 -5.14456,-2.78922 -5.14457,0 -11.1569,1.92146 -11.1569,16.79732 0,13.07836 3.34707,15.43371 9.23543,15.43371 4.09086,0 6.94207,-1.48759 6.94207,-3.16112 0,-0.80578 -0.18595,-1.61155 -0.49586,-2.72724 -1.05371,0.68181 -2.91319,1.4256 -4.89664,1.4256 -3.78095,0 -5.51647,-2.23138 -5.51647,-10.97095 0,-11.03293 3.22311,-12.33456 6.1363,-12.33456 1.67353,0 3.34707,0.55784 4.33879,1.11568 0.43388,-1.0537 0.55784,-2.10741 0.55784,-2.78922 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1362" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 140.76013,968.26676 c 0,13.94612 3.34707,16.11552 9.73129,16.11552 6.63216,0 10.16517,-4.77267 10.16517,-16.30147 0,-12.58249 -3.09913,-15.92956 -9.60732,-15.92956 -6.50819,0 -10.28914,4.77267 -10.28914,16.11551 z m 5.45448,0.12397 c 0,-9.66931 1.92147,-11.83871 4.64871,-11.83871 2.91319,0 4.33879,1.73552 4.33879,11.59078 0,9.66931 -1.92146,11.96267 -4.58672,11.96267 -2.85121,0 -4.40078,-1.48759 -4.40078,-11.71474 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1364" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 177.15563,983.76245 c 5.08258,0 5.0206,0 5.0206,-0.99172 v -24.97905 c 1.36362,-0.86776 2.72724,-1.17767 4.15285,-1.17767 2.47931,0 3.03715,1.23965 3.03715,4.21482 v 22.93362 c 4.83466,0 5.0206,0 5.0206,-0.99172 v -21.87991 c 0,-5.57845 -0.74379,-8.73957 -6.94206,-8.73957 -2.5413,0 -5.51647,0.74379 -7.62388,1.92146 -1.17767,-1.23965 -2.91319,-1.92146 -5.57845,-1.92146 -3.40905,0 -6.63216,0.80577 -9.3594,2.04543 v 29.56577 c 4.83466,0 5.02061,0 5.02061,-0.99172 v -25.165 c 1.4256,-0.74379 2.8512,-1.05371 4.21482,-1.05371 2.47931,0 2.97518,0.86776 3.03716,3.09914 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1366" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 210.98272,940.37452 c -1.36362,0 -1.67353,0.43388 -1.67353,1.17768 v 42.21025 h 7.74784 c 7.62388,0 12.08664,-5.76439 12.08664,-23.92534 0,-15.06181 -4.02888,-19.46259 -12.14862,-19.46259 z m 12.39655,18.96673 c 0,17.16922 -3.03715,19.64853 -6.26025,19.64853 h -2.78923 v -33.96655 h 2.85121 c 4.15284,0 6.19827,2.85121 6.19827,14.31802 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1368" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 243.80743,952.15125 c -5.45448,0 -10.97095,2.23138 -10.97095,17.72706 0,12.08664 4.15285,14.50397 9.91724,14.50397 4.64871,0 8.55362,-1.48759 8.55362,-3.40905 0,-0.99173 -0.12396,-2.47931 -0.43388,-3.40905 -2.10741,1.17767 -4.58672,1.92146 -7.06603,1.92146 -3.78095,0 -5.51647,-1.73552 -5.7644,-8.30569 2.97517,0 8.67759,-0.18595 12.9544,-0.99172 0.49586,-2.23138 0.68181,-5.33052 0.68181,-8.05776 0,-6.69414 -2.66526,-9.97922 -7.87181,-9.97922 z m -0.55785,4.40077 c 2.66526,0 3.47104,1.67354 3.53302,6.13629 0,1.17768 -0.062,2.60328 -0.30991,3.71897 -2.1694,0.61983 -6.01233,0.74379 -8.36767,0.68181 0.37189,-8.36767 2.60327,-10.53707 5.14456,-10.53707 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1370" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 260.74906,981.09719 c 0.43388,1.73552 1.05371,3.03716 2.23138,3.03716 0.80578,0 2.60328,0 3.53302,-0.18595 l 7.12802,-31.17733 c -5.08259,0 -5.14457,0 -5.33052,1.11569 l -1.67353,8.73957 c -1.23966,6.50819 -2.29337,15.74362 -2.29337,15.74362 h -0.12396 c 0,0 -1.11569,-9.23543 -2.41733,-15.68164 l -1.98345,-9.91724 c -5.51646,0 -5.70241,0 -5.3925,1.54957 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1372" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 286.0574,952.15125 c -5.45448,0 -10.97095,2.23138 -10.97095,17.72706 0,12.08664 4.15285,14.50397 9.91724,14.50397 4.64871,0 8.55362,-1.48759 8.55362,-3.40905 0,-0.99173 -0.12396,-2.47931 -0.43388,-3.40905 -2.10741,1.17767 -4.58672,1.92146 -7.06603,1.92146 -3.78095,0 -5.51647,-1.73552 -5.7644,-8.30569 2.97517,0 8.67759,-0.18595 12.9544,-0.99172 0.49586,-2.23138 0.68181,-5.33052 0.68181,-8.05776 0,-6.69414 -2.66526,-9.97922 -7.87181,-9.97922 z m -0.55785,4.40077 c 2.66526,0 3.47104,1.67354 3.53302,6.13629 0,1.17768 -0.062,2.60328 -0.30991,3.71897 -2.1694,0.61983 -6.01233,0.74379 -8.36768,0.68181 0.3719,-8.36767 2.60328,-10.53707 5.14457,-10.53707 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1374" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 303.43291,938.20513 c -4.02888,0 -5.0206,0 -5.0206,2.29336 v 43.26396 c 5.0206,0 5.0206,0 5.0206,-0.99172 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1376" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 307.82301,968.26676 c 0,13.94612 3.34707,16.11552 9.73129,16.11552 6.63216,0 10.16518,-4.77267 10.16518,-16.30147 0,-12.58249 -3.09914,-15.92956 -9.60733,-15.92956 -6.50819,0 -10.28914,4.77267 -10.28914,16.11551 z m 5.45448,0.12397 c 0,-9.66931 1.92147,-11.83871 4.64871,-11.83871 2.91319,0 4.33879,1.73552 4.33879,11.59078 0,9.66931 -1.92146,11.96267 -4.58672,11.96267 -2.85121,0 -4.40078,-1.48759 -4.40078,-11.71474 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1378" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 331.94594,993.80366 c 0,1.67353 0.68181,2.16939 2.41733,2.16939 0.80577,0 1.7975,-0.12396 2.60327,-0.43388 v -12.89241 c 0.92974,0.92974 2.60328,1.73552 4.89664,1.73552 4.21483,0 9.23543,-2.66526 9.23543,-19.33862 0,-10.16517 -3.96689,-12.89241 -10.10319,-12.89241 -3.34707,0 -6.50819,0.86776 -9.04948,2.47931 z m 5.0206,-36.07397 c 1.05371,-0.74379 2.29337,-1.17767 3.78095,-1.17767 3.16112,0 4.77267,1.67354 4.77267,9.04948 0,12.89242 -3.28508,14.25604 -5.20655,14.25604 -1.23965,0 -2.47931,-0.61983 -3.34707,-2.04543 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1380" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 365.7149,952.15125 c -5.45448,0 -10.97095,2.23138 -10.97095,17.72706 0,12.08664 4.15285,14.50397 9.91724,14.50397 4.64871,0 8.55362,-1.48759 8.55362,-3.40905 0,-0.99173 -0.12396,-2.47931 -0.43388,-3.40905 -2.10741,1.17767 -4.58672,1.92146 -7.06603,1.92146 -3.78095,0 -5.51647,-1.73552 -5.7644,-8.30569 2.97518,0 8.67759,-0.18595 12.9544,-0.99172 0.49586,-2.23138 0.68181,-5.33052 0.68181,-8.05776 0,-6.69414 -2.66526,-9.97922 -7.87181,-9.97922 z m -0.55785,4.40077 c 2.66526,0 3.47104,1.67354 3.53302,6.13629 0,1.17768 -0.062,2.60328 -0.30991,3.71897 -2.1694,0.61983 -6.01233,0.74379 -8.36767,0.68181 0.37189,-8.36767 2.60327,-10.53707 5.14456,-10.53707 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1382" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 378.00783,983.76245 c 5.0206,0 5.08258,0 5.08258,-0.99172 l 0.062,-24.35923 c 1.17767,-0.99172 2.72724,-1.4256 4.09086,-1.4256 1.05371,0 2.04543,0.24793 2.97517,0.74379 0.43388,-1.0537 0.55785,-2.29336 0.55785,-2.97517 0,-1.67353 -1.17768,-2.60327 -4.3388,-2.60327 -3.03715,0 -6.01232,1.11569 -8.42965,2.78922 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1384" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 415.3786,939.56875 c -5.51647,0 -12.21061,3.09914 -12.21061,24.29724 0,18.03698 4.40078,20.70224 10.28914,20.70224 4.58672,0 7.68586,-2.04543 7.68586,-4.46276 0,-1.05371 -0.37189,-2.23138 -0.74379,-3.03716 -1.11569,0.92975 -3.34707,1.92147 -5.70241,1.92147 -3.65699,0 -6.19828,-2.78922 -6.19828,-15.37172 0,-16.36345 3.9669,-19.15267 7.87181,-19.15267 1.92147,0 3.40905,0.99172 4.02888,1.54956 0.43388,-0.74379 0.80578,-1.85948 0.80578,-3.03715 0,-1.61155 -1.23966,-3.40905 -5.82638,-3.40905 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1386" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 422.83009,968.26676 c 0,13.94612 3.34707,16.11552 9.73129,16.11552 6.63216,0 10.16518,-4.77267 10.16518,-16.30147 0,-12.58249 -3.09914,-15.92956 -9.60733,-15.92956 -6.50819,0 -10.28914,4.77267 -10.28914,16.11551 z m 5.45448,0.12397 c 0,-9.66931 1.92147,-11.83871 4.64871,-11.83871 2.91319,0 4.33879,1.73552 4.33879,11.59078 0,9.66931 -1.92146,11.96267 -4.58672,11.96267 -2.85121,0 -4.40078,-1.48759 -4.40078,-11.71474 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1388" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 446.89101,983.76245 c 4.89663,0 5.0206,0 5.0206,-0.99172 v -25.10302 c 1.36362,-0.74379 3.28509,-1.11569 4.58672,-1.11569 3.09914,0 3.71897,1.48759 3.71897,5.3925 v 21.81793 c 5.08259,0 5.20655,0 5.20655,-0.99172 v -22.31379 c 0,-6.01233 -2.23138,-8.30569 -8.73957,-8.30569 -3.28508,0 -7.37595,1.0537 -9.79327,2.10741 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1390" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 472.85017,957.04788 v 26.71457 h 4.02888 c 0.92974,0 0.99172,-0.86776 0.99172,-0.99172 v -25.72285 h 4.52474 c 0.99173,0 1.05371,-0.30991 1.05371,-4.27681 h -5.57845 v -4.15284 c 0,-5.33052 2.97517,-6.07431 6.19828,-6.07431 1.36362,0 2.91319,0.12397 4.40077,0.74379 0.3719,-0.86776 0.55785,-1.92146 0.55785,-2.78922 0,-1.54957 -1.98345,-2.54129 -5.7644,-2.54129 -4.71069,0 -10.4131,1.48758 -10.4131,11.09491 v 3.71896 H 469.875 c -1.30164,0 -1.30164,0.30992 -1.30164,4.27681 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1392" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 495.37023,952.15125 c -5.45448,0 -10.97094,2.23138 -10.97094,17.72706 0,12.08664 4.15284,14.50397 9.91724,14.50397 4.6487,0 8.55362,-1.48759 8.55362,-3.40905 0,-0.99173 -0.12397,-2.47931 -0.43388,-3.40905 -2.10742,1.17767 -4.58673,1.92146 -7.06604,1.92146 -3.78094,0 -5.51646,-1.73552 -5.76439,-8.30569 2.97517,0 8.67758,-0.18595 12.95439,-0.99172 0.49587,-2.23138 0.68181,-5.33052 0.68181,-8.05776 0,-6.69414 -2.66525,-9.97922 -7.87181,-9.97922 z m -0.55784,4.40077 c 2.66526,0 3.47103,1.67354 3.53302,6.13629 0,1.17768 -0.062,2.60328 -0.30992,3.71897 -2.16939,0.61983 -6.01232,0.74379 -8.36767,0.68181 0.3719,-8.36767 2.60328,-10.53707 5.14457,-10.53707 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1394" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 507.66316,983.76245 c 5.02061,0 5.08259,0 5.08259,-0.99172 l 0.062,-24.35923 c 1.17767,-0.99172 2.72724,-1.4256 4.09086,-1.4256 1.05371,0 2.04543,0.24793 2.97518,0.74379 0.43387,-1.0537 0.55784,-2.29336 0.55784,-2.97517 0,-1.67353 -1.17767,-2.60327 -4.33879,-2.60327 -3.03716,0 -6.01233,1.11569 -8.42966,2.78922 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1396" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 532.7778,952.15125 c -5.45449,0 -10.97095,2.23138 -10.97095,17.72706 0,12.08664 4.15284,14.50397 9.91724,14.50397 4.64871,0 8.55362,-1.48759 8.55362,-3.40905 0,-0.99173 -0.12397,-2.47931 -0.43388,-3.40905 -2.10741,1.17767 -4.58672,1.92146 -7.06603,1.92146 -3.78095,0 -5.51647,-1.73552 -5.7644,-8.30569 2.97517,0 8.67759,-0.18595 12.9544,-0.99172 0.49586,-2.23138 0.68181,-5.33052 0.68181,-8.05776 0,-6.69414 -2.66526,-9.97922 -7.87181,-9.97922 z m -0.55785,4.40077 c 2.66526,0 3.47104,1.67354 3.53302,6.13629 0,1.17768 -0.062,2.60328 -0.30992,3.71897 -2.16939,0.61983 -6.01232,0.74379 -8.36767,0.68181 0.3719,-8.36767 2.60328,-10.53707 5.14457,-10.53707 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1398" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 545.07076,983.76245 c 4.89663,0 5.0206,0 5.0206,-0.99172 v -25.10302 c 1.36362,-0.74379 3.28508,-1.11569 4.58672,-1.11569 3.09914,0 3.71897,1.48759 3.71897,5.3925 v 21.81793 c 5.08258,0 5.20655,0 5.20655,-0.99172 v -22.31379 c 0,-6.01233 -2.23138,-8.30569 -8.73957,-8.30569 -3.28508,0 -7.37595,1.0537 -9.79327,2.10741 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1400" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 584.23218,954.94047 c 0,-1.61155 -2.29336,-2.78922 -5.14456,-2.78922 -5.14457,0 -11.1569,1.92146 -11.1569,16.79732 0,13.07836 3.34707,15.43371 9.23543,15.43371 4.09086,0 6.94207,-1.48759 6.94207,-3.16112 0,-0.80578 -0.18595,-1.61155 -0.49586,-2.72724 -1.05371,0.68181 -2.91319,1.4256 -4.89664,1.4256 -3.78095,0 -5.51647,-2.23138 -5.51647,-10.97095 0,-11.03293 3.22311,-12.33456 6.1363,-12.33456 1.67353,0 3.34706,0.55784 4.33879,1.11568 0.43388,-1.0537 0.55784,-2.10741 0.55784,-2.78922 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1402" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 597.30285,952.15125 c -5.45448,0 -10.97095,2.23138 -10.97095,17.72706 0,12.08664 4.15285,14.50397 9.91724,14.50397 4.64871,0 8.55362,-1.48759 8.55362,-3.40905 0,-0.99173 -0.12396,-2.47931 -0.43388,-3.40905 -2.10741,1.17767 -4.58672,1.92146 -7.06603,1.92146 -3.78095,0 -5.51646,-1.73552 -5.7644,-8.30569 2.97518,0 8.67759,-0.18595 12.9544,-0.99172 0.49586,-2.23138 0.68181,-5.33052 0.68181,-8.05776 0,-6.69414 -2.66526,-9.97922 -7.87181,-9.97922 z m -0.55784,4.40077 c 2.66525,0 3.47103,1.67354 3.53301,6.13629 0,1.17768 -0.062,2.60328 -0.30991,3.71897 -2.1694,0.61983 -6.01233,0.74379 -8.36767,0.68181 0.37189,-8.36767 2.60327,-10.53707 5.14457,-10.53707 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1404" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 620.14829,953.57685 c 2.04543,-1.23965 5.82638,-2.1694 9.04948,-2.1694 3.47104,0 4.77268,1.67354 4.77268,4.27681 0,6.88009 -8.73957,13.01638 -14.19405,22.12785 -1.17768,2.04543 -1.48759,2.66526 -1.48759,4.40077 0,0.30992 0.062,1.05371 0.18595,1.54957 h 21.01215 c 1.05371,0 1.05371,-1.4256 1.05371,-5.20655 0,0 -3.9669,0.43388 -7.31397,0.43388 h -8.30569 c 6.01233,-9.3594 14.7519,-15.37172 14.7519,-23.98733 0,-5.3925 -2.04543,-8.42965 -9.17345,-8.42965 -6.01232,0 -10.97095,1.7975 -10.97095,3.28508 0,0.86776 0.062,2.41733 0.61983,3.71897 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1406" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 644.19567,965.41556 c 0,12.27258 2.41733,18.90474 10.97095,18.90474 8.6156,0 11.34284,-6.94207 11.34284,-20.39233 0,-11.59077 -3.03715,-17.35517 -11.03293,-17.35517 -7.99577,0 -11.28086,6.57017 -11.28086,18.84276 z m 5.3925,0.37189 c 0,-9.23543 1.4256,-14.75189 6.13629,-14.75189 4.27681,0 5.51647,4.40077 5.51647,12.83043 0,11.15689 -1.73552,15.86758 -5.95035,15.86758 -4.27681,0 -5.70241,-3.71896 -5.70241,-13.94612 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1408" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 672.58184,952.89504 c 0,0 5.0206,-1.05371 7.06603,-1.11569 l -0.68181,27.21043 c -3.78094,0 -8.92551,0.24793 -8.92551,1.30164 0,0.99172 0.062,2.47931 0.12396,3.47103 h 21.1981 c 1.05371,0 1.05371,-1.54957 1.05371,-4.95862 0,0 -1.67353,0.18595 -3.595,0.18595 h -4.58672 l 0.80577,-32.10707 c -0.24793,-0.18595 -0.92974,-0.30991 -1.4256,-0.30991 -2.10741,0 -11.77672,2.10741 -11.77672,3.03715 0,1.23966 0.30991,2.41733 0.74379,3.28509 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1410" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 702.14568,985.374 c -1.54957,0 -3.03715,-0.18595 -4.52474,-0.61982 -0.18595,0.86775 -0.43388,2.41732 -0.43388,3.40905 0,1.48758 2.5413,2.04543 5.57845,2.04543 10.72302,0 15.43371,-7.99578 15.55767,-24.85509 -0.24793,-14.44198 -1.7975,-19.33862 -10.66103,-19.33862 -7.74785,0 -11.77672,4.95862 -11.77672,15.55768 0,8.11974 3.90491,12.45853 9.04948,12.45853 3.96689,0 6.4462,-1.48759 8.36767,-4.33879 -0.61983,9.17344 -3.2231,15.68163 -11.1569,15.68163 z m 4.27681,-15.99155 c -3.40905,0 -5.57844,-2.97517 -5.57844,-8.42965 0,-7.00405 2.66525,-10.47509 6.88008,-10.47509 4.89664,0 5.7644,4.83466 5.7644,14.07009 v 0.37189 c -2.04543,3.09914 -4.46276,4.46276 -7.06604,4.46276 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1412" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 722.78401,980.3534 c 0,1.36362 0.3719,2.41733 1.4256,3.03715 -0.12396,1.7975 -0.30991,2.91319 -1.73551,5.33052 0.24793,1.05371 1.0537,1.4256 1.98344,1.4256 1.11569,0 4.89664,-4.77267 4.89664,-9.29741 0,-2.54129 -1.23965,-3.71896 -3.40905,-3.71896 -1.85948,0 -3.16112,1.4256 -3.16112,3.2231 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1414" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 744.84019,953.57685 c 2.04543,-1.23965 5.82638,-2.1694 9.04948,-2.1694 3.47103,0 4.77267,1.67354 4.77267,4.27681 0,6.88009 -8.73957,13.01638 -14.19405,22.12785 -1.17767,2.04543 -1.48759,2.66526 -1.48759,4.40077 0,0.30992 0.062,1.05371 0.18595,1.54957 h 21.01216 c 1.0537,0 1.0537,-1.4256 1.0537,-5.20655 0,0 -3.96689,0.43388 -7.31396,0.43388 h -8.30569 c 6.01233,-9.3594 14.75189,-15.37172 14.75189,-23.98733 0,-5.3925 -2.04543,-8.42965 -9.17344,-8.42965 -6.01233,0 -10.97095,1.7975 -10.97095,3.28508 0,0.86776 0.062,2.41733 0.61983,3.71897 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1416" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 783.51549,945.02323 c 2.29337,0 4.27681,0.3719 5.82638,0.92974 0.3719,-1.17767 0.49587,-2.60327 0.49587,-3.595 0,-1.61155 -3.28509,-2.10741 -6.75612,-2.10741 -7.99578,0 -14.07009,5.95034 -14.07009,24.4212 0,11.96267 0.99172,19.58655 10.53707,19.58655 7.74784,0 11.77672,-5.08258 11.77672,-15.68163 0,-8.61561 -3.71896,-12.02466 -8.9875,-12.02466 -3.96689,0 -6.63215,1.48759 -8.49164,4.46276 0.43388,-11.46681 4.15285,-15.99155 9.66931,-15.99155 z m -2.66525,16.1775 c 3.595,0 5.51646,2.97517 5.51646,8.42965 0,5.7644 -2.29336,10.16517 -6.57017,10.16517 -4.15285,0 -6.13629,-3.96689 -5.95035,-13.6362 v -0.3719 c 1.98345,-3.09914 4.27681,-4.58672 7.00406,-4.58672 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1418" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 806.88106,968.51469 c 1.05371,0 1.05371,-1.30163 1.05371,-4.40077 h -11.65276 c -0.99172,0 -0.99172,1.23965 -0.99172,4.40077 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1420" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 813.8444,953.57685 c 2.04543,-1.23965 5.82638,-2.1694 9.04948,-2.1694 3.47103,0 4.77267,1.67354 4.77267,4.27681 0,6.88009 -8.73957,13.01638 -14.19405,22.12785 -1.17767,2.04543 -1.48758,2.66526 -1.48758,4.40077 0,0.30992 0.062,1.05371 0.18594,1.54957 h 21.01216 c 1.0537,0 1.0537,-1.4256 1.0537,-5.20655 0,0 -3.96689,0.43388 -7.31396,0.43388 h -8.30569 c 6.01233,-9.3594 14.7519,-15.37172 14.7519,-23.98733 0,-5.3925 -2.04544,-8.42965 -9.17345,-8.42965 -6.01233,0 -10.97095,1.7975 -10.97095,3.28508 0,0.86776 0.062,2.41733 0.61983,3.71897 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1422" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 844.02807,985.374 c -1.54957,0 -3.03716,-0.18595 -4.52474,-0.61982 -0.18595,0.86775 -0.43388,2.41732 -0.43388,3.40905 0,1.48758 2.54129,2.04543 5.57845,2.04543 10.72301,0 15.4337,-7.99578 15.55767,-24.85509 -0.24793,-14.44198 -1.7975,-19.33862 -10.66104,-19.33862 -7.74784,0 -11.77672,4.95862 -11.77672,15.55768 0,8.11974 3.90491,12.45853 9.04948,12.45853 3.9669,0 6.44621,-1.48759 8.36767,-4.33879 -0.61982,9.17344 -3.2231,15.68163 -11.15689,15.68163 z m 4.27681,-15.99155 c -3.40905,0 -5.57845,-2.97517 -5.57845,-8.42965 0,-7.00405 2.66526,-10.47509 6.88009,-10.47509 4.89663,0 5.76439,4.83466 5.76439,14.07009 v 0.37189 c -2.04543,3.09914 -4.46276,4.46276 -7.06603,4.46276 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1424" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 893.25595,983.76245 c 1.23965,0.12397 2.23138,0.12397 2.97517,0.12397 1.98345,0 2.29336,-0.3719 2.1694,-1.05371 L 887.3056,940.37452 c -0.61982,-0.12396 -1.48758,-0.18594 -2.35534,-0.18594 -1.11569,0 -1.7975,0.24793 -1.92147,0.86775 l -11.03293,42.64414 c 1.17768,0.12396 2.47931,0.18595 3.16113,0.18595 1.98344,0 2.16939,-0.30992 2.35534,-0.99173 l 2.41733,-10.16517 h 10.66103 z m -10.16517,-24.4212 c 0.92974,-4.15285 1.7975,-8.92552 2.16939,-11.90069 0.30992,2.97517 1.17768,7.80982 2.1694,11.90069 l 2.10741,8.80155 h -8.55362 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1426" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 901.65459,993.80366 c 0,1.67353 0.68181,2.16939 2.41733,2.16939 0.80577,0 1.7975,-0.12396 2.60327,-0.43388 v -12.89241 c 0.92974,0.92974 2.60328,1.73552 4.89664,1.73552 4.21483,0 9.23543,-2.66526 9.23543,-19.33862 0,-10.16517 -3.9669,-12.89241 -10.10319,-12.89241 -3.34707,0 -6.50819,0.86776 -9.04948,2.47931 z m 5.0206,-36.07397 c 1.05371,-0.74379 2.29336,-1.17767 3.78095,-1.17767 3.16112,0 4.77267,1.67354 4.77267,9.04948 0,12.89242 -3.28508,14.25604 -5.20655,14.25604 -1.23965,0 -2.47931,-0.61983 -3.34707,-2.04543 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1428" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 925.32039,983.76245 c 5.0206,0 5.08259,0 5.08259,-0.99172 l 0.062,-24.35923 c 1.17767,-0.99172 2.72724,-1.4256 4.09086,-1.4256 1.05371,0 2.04543,0.24793 2.97517,0.74379 0.43388,-1.0537 0.55785,-2.29336 0.55785,-2.97517 0,-1.67353 -1.17768,-2.60327 -4.3388,-2.60327 -3.03715,0 -6.01232,1.11569 -8.42965,2.78922 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1430" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 946.87008,952.77107 c -4.09086,0 -5.14457,0 -5.14457,2.29337 v 28.69801 c 5.08259,0 5.14457,0 5.14457,-0.99172 z m -5.08259,-9.85525 c 0,2.91319 0.92975,3.90491 2.5413,3.90491 1.92146,0 2.8512,-1.48759 2.8512,-4.02888 0.062,-2.60327 -0.55784,-3.595 -2.47931,-3.595 -1.98344,0 -2.8512,1.48759 -2.91319,3.71897 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1432" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 957.6415,938.20513 c -4.02888,0 -5.0206,0 -5.0206,2.29336 v 43.26396 c 5.0206,0 5.0206,0 5.0206,-0.99172 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1434" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 973.88584,953.57685 c 2.04543,-1.23965 5.82638,-2.1694 9.04948,-2.1694 3.47104,0 4.77268,1.67354 4.77268,4.27681 0,6.88009 -8.73957,13.01638 -14.19406,22.12785 -1.17767,2.04543 -1.48758,2.66526 -1.48758,4.40077 0,0.30992 0.062,1.05371 0.18595,1.54957 h 21.01215 c 1.05371,0 1.05371,-1.4256 1.05371,-5.20655 0,0 -3.9669,0.43388 -7.31397,0.43388 h -8.30569 c 6.01233,-9.3594 14.7519,-15.37172 14.7519,-23.98733 0,-5.3925 -2.04543,-8.42965 -9.17345,-8.42965 -6.01233,0 -10.97095,1.7975 -10.97095,3.28508 0,0.86776 0.062,2.41733 0.61983,3.71897 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1436" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 997.93322,965.41556 c 0,12.27258 2.41728,18.90474 10.97098,18.90474 8.6156,0 11.3428,-6.94207 11.3428,-20.39233 0,-11.59077 -3.0371,-17.35517 -11.0329,-17.35517 -7.9958,0 -11.28088,6.57017 -11.28088,18.84276 z m 5.39248,0.37189 c 0,-9.23543 1.4256,-14.75189 6.1363,-14.75189 4.2768,0 5.5165,4.40077 5.5165,12.83043 0,11.15689 -1.7355,15.86758 -5.9504,15.86758 -4.2768,0 -5.7024,-3.71896 -5.7024,-13.94612 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1438" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 1026.3194,952.89504 c 0,0 5.0206,-1.05371 7.066,-1.11569 l -0.6818,27.21043 c -3.7809,0 -8.9255,0.24793 -8.9255,1.30164 0,0.99172 0.062,2.47931 0.124,3.47103 h 21.1981 c 1.0537,0 1.0537,-1.54957 1.0537,-4.95862 0,0 -1.6736,0.18595 -3.595,0.18595 h -4.5868 l 0.8058,-32.10707 c -0.2479,-0.18595 -0.9297,-0.30991 -1.4256,-0.30991 -2.1074,0 -11.7767,2.10741 -11.7767,3.03715 0,1.23966 0.3099,2.41733 0.7438,3.28509 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1440" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 1055.8832,985.374 c -1.5495,0 -3.0371,-0.18595 -4.5247,-0.61982 -0.186,0.86775 -0.4339,2.41732 -0.4339,3.40905 0,1.48758 2.5413,2.04543 5.5785,2.04543 10.723,0 15.4337,-7.99578 15.5576,-24.85509 -0.2479,-14.44198 -1.7975,-19.33862 -10.661,-19.33862 -7.7478,0 -11.7767,4.95862 -11.7767,15.55768 0,8.11974 3.9049,12.45853 9.0495,12.45853 3.9669,0 6.4462,-1.48759 8.3676,-4.33879 -0.6198,9.17344 -3.2231,15.68163 -11.1569,15.68163 z m 4.2768,-15.99155 c -3.409,0 -5.5784,-2.97517 -5.5784,-8.42965 0,-7.00405 2.6653,-10.47509 6.8801,-10.47509 4.8966,0 5.7644,4.83466 5.7644,14.07009 v 0.37189 c -2.0455,3.09914 -4.4628,4.46276 -7.0661,4.46276 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1442" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 1076.5216,980.3534 c 0,1.36362 0.3719,2.41733 1.4256,3.03715 -0.124,1.7975 -0.31,2.91319 -1.7356,5.33052 0.248,1.05371 1.0538,1.4256 1.9835,1.4256 1.1157,0 4.8966,-4.77267 4.8966,-9.29741 0,-2.54129 -1.2396,-3.71896 -3.409,-3.71896 -1.8595,0 -3.1611,1.4256 -3.1611,3.2231 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1444" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 1097.586,983.76245 h 7.8098 c 6.4462,0 11.7768,-4.33879 11.7768,-14.75189 0,-7.43793 -4.4628,-8.86354 -7.314,-9.04949 2.6653,-0.37189 5.9503,-3.16112 5.9503,-9.97922 0,-7.99577 -5.4544,-9.60733 -10.4131,-9.60733 h -6.1363 c -1.3016,0 -1.6735,0.43388 -1.6735,1.17768 z m 5.1446,-38.92517 h 2.9752 c 2.3553,0 4.5867,1.05371 4.5867,6.13629 0,4.89664 -1.9215,7.12802 -4.5248,7.12802 h -3.0371 z m 0,17.6031 h 2.8512 c 3.3471,0 5.7024,0.61983 5.7024,7.00406 0,7.06603 -2.6653,9.91724 -5.7644,9.91724 h -2.7892 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1446" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 1131.1777,952.15125 c -5.4545,0 -10.971,2.23138 -10.971,17.72706 0,12.08664 4.1529,14.50397 9.9173,14.50397 4.6487,0 8.5536,-1.48759 8.5536,-3.40905 0,-0.99173 -0.124,-2.47931 -0.4339,-3.40905 -2.1074,1.17767 -4.5867,1.92146 -7.066,1.92146 -3.781,0 -5.5165,-1.73552 -5.7644,-8.30569 2.9751,0 8.6776,-0.18595 12.9544,-0.99172 0.4958,-2.23138 0.6818,-5.33052 0.6818,-8.05776 0,-6.69414 -2.6653,-9.97922 -7.8718,-9.97922 z m -0.5579,4.40077 c 2.6653,0 3.4711,1.67354 3.533,6.13629 0,1.17768 -0.062,2.60328 -0.3099,3.71897 -2.1694,0.61983 -6.0123,0.74379 -8.3676,0.68181 0.3719,-8.36767 2.6032,-10.53707 5.1445,-10.53707 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1448" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 1143.4706,983.76245 c 5.0206,0 5.0826,0 5.0826,-0.99172 l 0.062,-24.35923 c 1.1776,-0.99172 2.7272,-1.4256 4.0908,-1.4256 1.0537,0 2.0455,0.24793 2.9752,0.74379 0.4339,-1.0537 0.5578,-2.29336 0.5578,-2.97517 0,-1.67353 -1.1776,-2.60327 -4.3387,-2.60327 -3.0372,0 -6.0124,1.11569 -8.4297,2.78922 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1450" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 1164.8963,938.20513 c -4.0289,0 -5.0206,0 -5.0206,2.29336 v 43.26396 c 5.0206,0 5.0206,0 5.0206,-0.99172 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1452" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 1199.6425,983.76245 c 4.8966,0 5.0206,0 5.0206,-0.99172 v -25.10302 c 1.3636,-0.74379 3.2851,-1.11569 4.5867,-1.11569 3.0991,0 3.719,1.48759 3.719,5.3925 v 21.81793 c 5.0826,0 5.2065,0 5.2065,-0.99172 v -22.31379 c 0,-6.01233 -2.2314,-8.30569 -8.7396,-8.30569 -3.285,0 -7.3759,1.0537 -9.7932,2.10741 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px"
+         id="path1454" />
+    </g>
+    <g
+       style="display:inline"
+       transform="matrix(4.0085474,0,0,4.0085474,922.49571,551.38119)"
+       id="g27740-6">
+      <g
+         id="g28309-1">
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:normal;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.98000004;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6.24451828;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           d="m 3820.6562,472.26172 c -40.3422,0 -73.1445,32.3975 -73.1445,72.32812 0,30.32091 18.9212,56.28015 45.6875,67.02735 l 1.8555,-5.95508 c -24.2644,-9.91834 -41.2988,-33.51066 -41.2988,-61.07227 0,-36.51604 29.8935,-66.08398 66.9003,-66.08398 37.0069,0 66.8985,29.56794 66.8985,66.08398 0,24.66524 -13.6587,46.14338 -33.918,57.50977 -2.3907,1.34129 -4.8745,2.53952 -7.4355,3.58594 l 1.8535,5.96875 c 2.9828,-1.19355 5.8704,-2.56971 8.6426,-4.125 22.1465,-12.42531 37.1035,-35.96788 37.1035,-62.93946 0,-39.93062 -32.8023,-72.32812 -73.1446,-72.32812 z m 7.5,137.99414 c -2.4618,0.2706 -4.962,0.41602 -7.5,0.41602 -2.5028,0 -4.9696,-0.14473 -7.4003,-0.40821 l -1.8633,6.05469 c 3.0363,0.3807 6.1241,0.59767 9.2636,0.59766 3.182,0 6.3161,-0.2044 9.3926,-0.59571 z"
+           id="path3544-2-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ssccsssscccsscsccccc"
+           transform="matrix(0.04785074,0,0,0.04785074,-118.05951,92.995687)" />
+        <path
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a00000;stroke-width:6.34386444px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 3811.3887,563.87891 -30.2735,97.13867 h 78.9297 l -30.1523,-97.125 c -2.8017,1.31925 -5.9315,2.05859 -9.2364,2.05859 -3.3169,0 -6.4581,-0.74396 -9.2675,-2.07226 z m 9.2675,11.66406 19.3165,61.84961 h -38.4082 z"
+           transform="matrix(0.04785074,0,0,0.04785074,-118.05951,92.995687)"
+           id="path3548-6-5"
+           inkscape:connector-curvature="0" />
+        <path
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#a00000;stroke-width:0.3038334;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path3556-1-4"
+           d="m 65.796938,119.04618 c 0,0.56924 -0.463484,1.03071 -1.035215,1.03071 -0.571734,0 -1.035215,-0.46147 -1.035215,-1.03071 0,-0.56925 0.463481,-1.03071 1.035215,-1.03071 0.571731,0 1.035215,0.46146 1.035215,1.03071 z"
+           inkscape:connector-curvature="0" />
+      </g>
+      <path
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#3465a4;stroke-width:0.29880485;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3552-8-7"
+         d="m 66.957088,119.05451 c 0,1.21246 -0.982899,2.19537 -2.195365,2.19537 -1.212466,0 -2.195365,-0.98291 -2.195365,-2.19537 0,-1.21246 0.982899,-2.19537 2.195365,-2.19537 1.212466,0 2.195365,0.98291 2.195365,2.19537 z"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="title"
+     style="display:inline">
+    <g
+       id="cclogo-9"
+       inkscape:label="Layer 1"
+       transform="matrix(1.4786532,0,0,1.4786532,811.2808,407.8477)"
+       style="display:inline;stroke-width:0.63402295">
+      <g
+         inkscape:export-ydpi="300.23013"
+         inkscape:export-xdpi="300.23013"
+         inkscape:export-filename="/mnt/hgfs/Bov/Documents/Work/2007/cc/identity/srr buttons/big/by.png"
+         id="g260-2"
+         transform="matrix(0.9937728,0,0,0.9936696,-177.69267,6.25128e-7)"
+         style="stroke-width:0.63402295">
+        <path
+           style="fill:#aab2ab;stroke-width:0.63402295"
+           d="m 181.96579,0.51074 114.06396,0.20264 c 1.59375,0 3.01758,-0.23633 3.01758,3.18066 l -0.13965,37.56689 H 179.08737 V 3.75439 c 0,-1.68505 0.16309,-3.24365 2.87842,-3.24365 z"
+           nodetypes="ccccccc"
+           id="path3817_1_-6"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path263-6"
+           d="m 297.29636,0 h -116.229 c -1.24658,0 -2.26123,1.01416 -2.26123,2.26074 v 39.49658 c 0,0.28174 0.229,0.51025 0.51074,0.51025 h 119.73047 c 0.28174,0 0.51074,-0.22852 0.51074,-0.51025 V 2.26074 C 299.55807,1.01416 298.54343,0 297.29636,0 Z M 181.06735,1.02148 h 116.229 c 0.68408,0 1.24023,0.55566 1.24023,1.23926 0,0 0,15.94824 0,27.44971 h -83.34424 c -3.04492,5.50586 -8.91113,9.24414 -15.64355,9.24414 -6.73535,0 -12.6001,-3.73486 -15.64355,-9.24414 h -4.07764 c 0,-11.50146 0,-27.44971 0,-27.44971 1e-5,-0.68359 0.55616,-1.23926 1.23975,-1.23926 z"
+           inkscape:connector-curvature="0"
+           style="stroke-width:0.63402295" />
+        <g
+           id="g265-4"
+           enable-background="new    "
+           style="stroke-width:0.63402295">
+          <path
+             style="fill:#ffffff;stroke-width:0.63402295"
+             id="path267-9"
+             d="m 253.07761,32.95605 c 0.31738,0 0.60742,0.02832 0.87012,0.08398 0.26172,0.05566 0.48535,0.14746 0.67285,0.27539 0.18652,0.12695 0.33203,0.29688 0.43457,0.50781 0.10254,0.21191 0.1543,0.47266 0.1543,0.78418 0,0.33594 -0.0762,0.61523 -0.22949,0.83887 -0.15234,0.22461 -0.37891,0.40723 -0.67773,0.55078 0.41211,0.11816 0.71973,0.3252 0.92285,0.62109 0.20312,0.29589 0.30469,0.65234 0.30469,1.06934 0,0.33594 -0.0654,0.62695 -0.19629,0.87305 -0.13086,0.24512 -0.30762,0.44629 -0.52832,0.60156 -0.22168,0.15625 -0.47461,0.27148 -0.75781,0.3457 -0.28418,0.0752 -0.5752,0.1123 -0.875,0.1123 H 249.936 v -6.66406 h 3.14161 z m -0.1875,2.69532 c 0.26172,0 0.47656,-0.0625 0.64551,-0.18652 0.16797,-0.12402 0.25195,-0.3252 0.25195,-0.60449 0,-0.15527 -0.0283,-0.2832 -0.084,-0.38184 -0.0566,-0.09961 -0.13086,-0.17676 -0.22461,-0.2334 -0.0937,-0.05566 -0.20117,-0.09473 -0.32227,-0.11621 -0.1211,-0.02148 -0.24805,-0.03223 -0.37793,-0.03223 h -1.37402 v 1.55469 z m 0.0859,2.82812 c 0.14355,0 0.28027,-0.01367 0.41113,-0.04199 0.13086,-0.02832 0.24609,-0.0752 0.34668,-0.13965 0.0996,-0.06543 0.17871,-0.1543 0.23828,-0.2666 0.0596,-0.11133 0.0889,-0.25488 0.0889,-0.42871 0,-0.3418 -0.0967,-0.58594 -0.29004,-0.73242 -0.19336,-0.14551 -0.44922,-0.21875 -0.7666,-0.21875 h -1.59961 v 1.82812 z"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:#ffffff;stroke-width:0.63402295"
+             id="path269-5"
+             d="m 255.78854,32.95605 h 1.64355 l 1.56055,2.63184 1.55078,-2.63184 h 1.63379 l -2.47363,4.10645 v 2.55762 h -1.46875 v -2.59473 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(0.872921,0,0,0.872921,50.12536,143.2144)"
+           id="g5908_1_-0"
+           style="stroke-width:0.63402295">
+          <path
+             style="fill:#ffffff;stroke-width:0.63402295"
+             d="m 186.90065,-141.46002 c 0.006,8.68079 -7.02786,15.7215 -15.70808,15.72711 -8.68022,0.006 -15.72206,-7.02734 -15.7271,-15.70807 0,-0.006 0,-0.0123 0,-0.019 -0.005,-8.68079 7.02786,-15.7215 15.70808,-15.72656 8.68135,-0.006 15.72206,7.02734 15.7271,15.70813 0,0.006 0,0.0123 0,0.0184 z"
+             rx="22.939548"
+             type="arc"
+             cy="264.3577"
+             ry="22.939548"
+             cx="296.35416"
+             id="path5906_1_-4"
+             inkscape:connector-curvature="0" />
+          <g
+             transform="translate(-289.6157,99.0653)"
+             id="g5706_1_-8"
+             style="stroke-width:0.63402295">
+            <path
+               d="m 473.57574,-253.32751 c 3.48541,3.48541 5.22839,7.75391 5.22839,12.80219 0,5.04938 -1.71277,9.27203 -5.13831,12.66791 -3.63531,3.5766 -7.93182,5.36432 -12.88947,5.36432 -4.89777,0 -9.11987,-1.77319 -12.66513,-5.31952 -3.54581,-3.54584 -5.31845,-7.78302 -5.31845,-12.71271 0,-4.92859 1.77264,-9.19598 5.31845,-12.80219 3.4552,-3.48651 7.67728,-5.22949 12.66513,-5.22949 5.0483,-10e-6 9.31404,1.74297 12.79939,5.22949 z m -23.11798,2.34484 c -2.94672,2.97638 -4.41953,6.46289 -4.41953,10.46234 0,3.99835 1.45828,7.45526 4.37424,10.37067 2.9165,2.9165 6.38849,4.37421 10.41705,4.37421 4.02856,0 7.53015,-1.47223 10.50653,-4.4184 2.82593,-2.73645 4.23944,-6.17706 4.23944,-10.32648 0,-4.11804 -1.43646,-7.61346 -4.30768,-10.48468 -2.87067,-2.87067 -6.34991,-4.30658 -10.43829,-4.30658 -4.0884,1e-5 -7.54638,1.44318 -10.37176,4.32892 z m 7.75449,8.70319 c -0.45029,-0.98169 -1.1243,-1.47284 -2.02322,-1.47284 -1.58917,0 -2.38345,1.07007 -2.38345,3.20911 0,2.13953 0.79428,3.2085 2.38345,3.2085 1.04938,0 1.79892,-0.52075 2.24866,-1.56451 l 2.20276,1.17297 c -1.04993,1.86548 -2.62509,2.79846 -4.72549,2.79846 -1.6199,0 -2.91763,-0.4967 -3.89206,-1.48901 -0.9761,-0.99341 -1.46274,-2.36273 -1.46274,-4.10852 0,-1.71503 0.50229,-3.07654 1.50748,-4.08502 1.00519,-1.00854 2.25702,-1.51257 3.75781,-1.51257 2.22012,0 3.80981,0.87488 4.77081,2.62286 z m 10.36337,0 c -0.45087,-0.98169 -1.11145,-1.47284 -1.98242,-1.47284 -1.62103,0 -2.43213,1.07007 -2.43213,3.20911 0,2.13953 0.8111,3.2085 2.43213,3.2085 1.05109,0 1.78717,-0.52075 2.20728,-1.56451 l 2.25201,1.17297 c -1.04828,1.86548 -2.62122,2.79846 -4.71771,2.79846 -1.61768,0 -2.9126,-0.4967 -3.88647,-1.48901 -0.97217,-0.99341 -1.45935,-2.36273 -1.45935,-4.10852 0,-1.71503 0.49445,-3.07654 1.48285,-4.08502 0.98785,-1.00854 2.2453,-1.51257 3.7735,-1.51257 2.21619,0 3.80365,0.87488 4.76129,2.62286 z"
+               id="path5708_1_-7"
+               inkscape:connector-curvature="0"
+               style="stroke-width:0.63402295" />
+          </g>
+        </g>
+        <g
+           id="g275-1"
+           style="stroke-width:0.63402295">
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:#ffffff;stroke-width:0.63402295"
+             d="M 266.35788,15.31348 A 10.80664,10.80664 0 0 1 255.55124,26.12012 10.80664,10.80664 0 0 1 244.7446,15.31348 10.80664,10.80664 0 0 1 255.55124,4.5068407 10.80664,10.80664 0 0 1 266.35788,15.31348 Z"
+             id="circle277-7" />
+          <g
+             id="g279-2"
+             style="stroke-width:0.63402295">
+            <path
+               id="path281-7"
+               d="m 258.67819,12.18701 c 0,-0.4165 -0.33789,-0.75391 -0.75293,-0.75391 h -4.77344 c -0.41504,0 -0.75293,0.3374 -0.75293,0.75391 v 4.77295 h 1.33105 v 5.65186 h 3.61719 v -5.65186 h 1.33105 v -4.77295 z"
+               inkscape:connector-curvature="0"
+               style="stroke-width:0.63402295" />
+            <path
+               inkscape:connector-curvature="0"
+               style="stroke-width:0.63402295"
+               d="m 257.17135,9.1723604 a 1.63281,1.63281 0 0 1 -1.63281,1.6328096 1.63281,1.63281 0 0 1 -1.63281,-1.6328096 1.63281,1.63281 0 0 1 1.63281,-1.63281 1.63281,1.63281 0 0 1 1.63281,1.63281 z"
+               id="circle283-2" />
+          </g>
+          <path
+             style="clip-rule:evenodd;fill-rule:evenodd;stroke-width:0.63402295"
+             id="path285-2"
+             d="m 255.5239,3.40723 c -3.23242,0 -5.96875,1.12793 -8.20801,3.38379 -2.29785,2.3335 -3.44629,5.0957 -3.44629,8.28467 0,3.18897 1.14844,5.93164 3.44629,8.22656 2.29785,2.29443 5.03418,3.44189 8.20801,3.44189 3.21289,0 5.99805,-1.15625 8.35352,-3.47119 2.21973,-2.19727 3.33008,-4.92969 3.33008,-8.19727 0,-3.26758 -1.12988,-6.02881 -3.3877,-8.28467 -2.25977,-2.25585 -5.02442,-3.38378 -8.2959,-3.38378 z m 0.0293,2.09961 c 2.64844,0 4.89746,0.93408 6.74707,2.80127 1.86914,1.84717 2.80371,4.10303 2.80371,6.76758 0,2.68359 -0.91504,4.91064 -2.74512,6.68018 -1.92871,1.90625 -4.19629,2.85889 -6.80566,2.85889 -2.61035,0 -4.85938,-0.94287 -6.74707,-2.82959 -1.88965,-1.88672 -2.83301,-4.12305 -2.83301,-6.70947 0,-2.58691 0.9541,-4.84229 2.8623,-6.76758 1.83009,-1.8672 4.06934,-2.80128 6.71778,-2.80128 z"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+    <g
+       id="g543"
+       transform="translate(155.35714,117.85714)">
+      <g
+         transform="matrix(2.0475567,0,0,2.0475567,298.8262,-6.2026343)"
+         id="g3732-6-8"
+         style="display:inline">
+        <path
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;opacity:0.8;fill:url(#radialGradient3637-3-3);fill-opacity:1;stroke:url(#radialGradient3639-5-5);stroke-width:1.46151388;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+           id="path3544-1-7"
+           d="m 60.69548,67.493897 c 0,11.5675 -9.48796,20.9448 -21.19195,20.9448 -11.703989,0 -21.191949,-9.3773 -21.191949,-20.9448 0,-11.5674 9.48796,-20.9447 21.191949,-20.9447 11.70399,0 21.19195,9.3773 21.19195,20.9447 z"
+           inkscape:connector-curvature="0" />
+        <g
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:#000000;fill-opacity:1;stroke:none"
+           id="g3546-8-9"
+           transform="matrix(1.4615138,0,0,2.5218672,4.4272,31.547917)">
+          <path
+             style="fill:url(#linearGradient3991-3-88-5);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3993-1-9-7);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             id="path3548-79-2"
+             d="m 24,13 -8.1875,15.225744 c 11.445471,0 5.976697,0 16.34375,0 z m 0,4.96875 4,7.421875 h -7.953125 z"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:none;stroke:#ffffff;stroke-width:1.31358945px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+             id="path3550-2-0"
+             transform="matrix(1,0,0,0.57953638,4,2.7937247)"
+             d="M 26.355979,42.522608 20,21.277828 13.644021,42.522609"
+             inkscape:connector-curvature="0" />
+        </g>
+        <path
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:url(#radialGradient3995-7-4-0-2-2-0-9-0);fill-opacity:1;stroke:url(#radialGradient3997-3-3-4-7-7-6-1-9-91);stroke-width:1.46151388;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+           id="path3552-0-2"
+           d="m 53.38791,67.493897 c 0,7.6681 -6.21625,13.8844 -13.88438,13.8844 -7.66813,0 -13.884379,-6.2163 -13.884379,-13.8844 0,-7.6681 6.216249,-13.8844 13.884379,-13.8844 7.66813,0 13.88438,6.2163 13.88438,13.8844 z"
+           inkscape:connector-curvature="0" />
+        <g
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:#000000;fill-opacity:1;stroke:none"
+           id="g3554-2-3"
+           transform="matrix(3.2735609,0,0,3.2593101,-24.33091,59.292917)">
+          <path
+             style="fill:url(#radialGradient3999-1-4-6-0-0-3-2-36);fill-opacity:1;stroke:#555753;stroke-width:0.39671427;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+             id="path3556-3-7"
+             transform="matrix(1.1130433,0,0,1.1428572,9.2565233,-0.07142864)"
+             d="M 11,2.25 C 11,3.2164983 10.195512,4 9.203125,4 8.2107383,4 7.40625,3.2164983 7.40625,2.25 7.40625,1.2835017 8.2107383,0.5 9.203125,0.5 10.195512,0.5 11,1.2835017 11,2.25 Z"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:#ffffff;fill-opacity:1;stroke:none"
+             id="path3558-7-5"
+             transform="matrix(1.8125,0,0,1.8125,-16.465404,-0.9288198)"
+             d="M 20,1.5 C 20,1.7761424 19.776142,2 19.5,2 19.223858,2 19,1.7761424 19,1.5 19,1.2238576 19.223858,1 19.5,1 19.776142,1 20,1.2238576 20,1.5 Z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <path
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:url(#radialGradient4001-9-6-9-6-60-6-9-2);stroke-width:1.46151364;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+           id="path3560-5-9"
+           d="m 44.61882,67.441097 c 0,2.8124 -2.2902,5.0924 -5.1153,5.0924 -2.8251,0 -5.1153,-2.28 -5.1153,-5.0924 0,-2.8125 2.2902,-5.0924 5.1153,-5.0924 2.8251,0 5.1153,2.2799 5.1153,5.0924 z"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="text3743-6-9-2"
+         style="font-style:normal;font-weight:normal;font-size:131.04367065px;line-height:125%;font-family:Sans;letter-spacing:0.28665793px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         aria-label="Os"
+         transform="translate(-543.64573,65.472005)">
+        <path
+           id="path381"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';letter-spacing:0.28665793px;fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 972.19144,89.895193 c 0,37.740577 6.68323,47.568857 23.58786,47.568857 17.2978,0 24.7673,-11.92498 24.7673,-47.961988 0,-35.381791 -6.2901,-46.127372 -23.32582,-46.127372 -16.90463,0 -25.02934,11.662887 -25.02934,46.520503 z m 11.92498,2.620874 c 0,-28.305433 3.66922,-38.264752 12.84228,-38.264752 9.4351,0 12.056,9.3041 12.056,35.512835 0,26.73291 -3.2761,36.82327 -12.71122,36.82327 -9.3041,0 -12.18706,-9.69723 -12.18706,-34.071353 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path383"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';letter-spacing:0.28665793px;fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1050.0211,69.452381 c -14.6768,0 -21.3601,6.290096 -21.3601,15.463153 0,4.324441 1.5726,9.042013 7.4695,13.890629 l 12.7113,10.876627 c 3.9313,3.53818 5.2417,6.68322 5.2417,10.2214 0,5.24175 -3.9313,8.12471 -10.6145,8.12471 -5.1107,0 -9.3041,-1.04835 -13.1044,-3.27609 -1.4415,2.35879 -1.8346,4.58653 -1.8346,6.15905 0,4.58653 6.6832,6.68323 15.9873,6.68323 13.3665,0 21.6222,-6.55218 21.6222,-18.21507 0,-6.55218 -2.0967,-10.87663 -7.7316,-16.38046 l -12.187,-9.828275 c -4.4555,-3.669223 -5.2418,-5.765921 -5.2418,-8.124708 0,-4.062353 4.1934,-6.290096 10.3525,-6.290096 4.9796,0 8.911,1.04835 12.8423,3.407136 1.4414,-1.572524 2.3587,-3.669223 2.3587,-5.372791 0,-2.620873 -3.014,-7.338445 -16.5115,-7.338445 z"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="text3760-7-2-8"
+         style="font-style:normal;font-weight:normal;font-size:81.90226746px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         aria-label="o"
+         transform="translate(-543.64573,65.472005)">
+        <path
+           id="path386"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1154.9617,103.52374 c 0,29.48482 7.0764,34.07135 20.5739,34.07135 14.0216,0 21.4911,-10.09036 21.4911,-34.46449 0,-26.601861 -6.5522,-33.678219 -20.3118,-33.678219 -13.7595,0 -21.7532,10.090362 -21.7532,34.071359 z m 11.5318,0.26208 c 0,-20.44281 4.0624,-25.029339 9.8283,-25.029339 6.1591,0 9.1731,3.669223 9.1731,24.505169 0,20.44281 -4.0624,25.29143 -9.6973,25.29143 -6.028,0 -9.3041,-3.14505 -9.3041,-24.76726 z"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="text4707-97-7"
+         style="font-style:normal;font-weight:bold;font-size:131.04367065px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Yanone Kaffeesatz Bold';letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         aria-label="DevCon"
+         transform="translate(-543.64573,65.472005)">
+        <path
+           id="path389"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1209.8369,45.864447 c -2.883,0 -3.6693,0.917306 -3.6693,2.620873 v 89.1097 h 16.9047 c 17.6909,0 25.0293,-15.46316 25.0293,-50.451817 0,-33.678223 -8.2557,-41.278756 -25.6845,-41.278756 z m 21.3601,39.706232 c 0,33.285091 -3.6692,38.133711 -7.7316,38.133711 h -2.6209 V 59.230901 h 2.4899 c 4.7175,0 7.8626,2.882961 7.8626,26.339778 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path391"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1276.5565,70.762744 c -12.3181,0 -23.0637,5.503835 -23.0637,37.216406 0,24.89829 8.3868,30.9263 20.3118,30.9263 10.2214,0 18.6082,-2.88296 18.6082,-8.1247 0,-3.01401 -0.3931,-7.20741 -1.1794,-9.82828 -4.5865,2.22774 -9.173,3.66922 -13.8906,3.66922 -6.2901,0 -8.1247,-3.66922 -8.5179,-11.92497 6.4212,-0.13104 16.2495,-0.65522 22.6706,-1.96566 1.3104,-5.1107 1.8346,-12.318101 1.8346,-18.608197 0,-15.201066 -6.2901,-21.360119 -16.7736,-21.360119 z m -1.9656,12.711236 c 3.2761,0 4.4554,1.310437 4.4554,9.697232 0,2.096699 -0.131,5.241747 -0.6552,6.814271 -1.9656,0.917307 -6.028,1.179397 -9.6972,1.179397 0.3931,-11.924978 1.8346,-17.6909 5.897,-17.6909 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path393"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1308.3612,131.69805 c 0.7863,3.66922 2.3588,6.55218 6.1591,6.55218 2.7519,0 7.6005,-0.13104 10.6145,-0.65521 l 13.1044,-65.521839 c -15.07,0 -15.07,0 -15.4632,2.882961 l -1.8346,15.987328 c -1.3104,11.26976 -2.4898,31.31944 -2.4898,31.31944 h -0.2621 c 0,0 -1.1794,-20.04968 -2.6209,-31.31944 l -2.3588,-18.870289 c -16.7735,0 -16.9046,0 -15.9873,4.324441 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path395"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1368.2584,43.898792 c -11.7939,0 -26.2087,7.86262 -26.2087,50.844944 0,36.692224 7.0764,44.816934 21.8843,44.816934 9.9593,0 15.9873,-3.53818 15.9873,-9.69723 0,-3.14505 -0.9173,-6.42114 -1.9656,-8.64888 -2.4899,1.31043 -6.1591,1.96565 -10.2214,1.96565 -7.3385,0 -10.2215,-6.81427 -10.2215,-29.615867 0,-28.56752 6.8143,-35.381791 14.2838,-35.381791 2.883,0 5.2418,1.048349 6.8143,2.227742 1.0483,-2.227742 2.0967,-5.241746 2.0967,-8.779925 0,-3.931311 -1.3105,-7.731577 -12.4492,-7.731577 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path397"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1382.3395,104.70306 c 0,29.35378 6.5522,34.20239 20.7049,34.20239 14.1527,0 21.4911,-9.43514 21.4911,-34.72657 0,-26.470821 -6.4211,-33.416136 -20.4428,-33.416136 -13.8906,0 -21.7532,10.221407 -21.7532,33.940316 z m 16.1184,-0.13105 c 0,-18.6082 2.2277,-21.229073 5.1107,-21.229073 3.8002,0 4.8486,2.358786 4.8486,21.229073 0,20.18073 -2.4899,22.14638 -4.9797,22.14638 -3.2761,0 -4.9796,-1.70357 -4.9796,-22.14638 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path399"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1430.7683,137.59502 c 14.4148,0 14.6769,0 14.6769,-2.62088 V 84.915461 c 1.4415,-1.048349 3.2761,-1.572524 4.9797,-1.572524 3.6692,0 4.3244,2.096699 4.3244,8.910969 v 45.341114 c 14.8079,0 15.2011,0 15.2011,-2.62088 V 87.667378 c 0,-13.104367 -5.6349,-16.904634 -18.8703,-16.904634 -6.5522,0 -16.2494,2.358787 -20.3118,4.324442 z"
+           inkscape:connector-curvature="0" />
+      </g>
+      <path
+         inkscape:connector-curvature="0"
+         id="path3959-9-26-3-1-6"
+         d="m 551.9174,135.85483 -8.87409,15.27271 -4.0593,-6.9865 1.2039,55.02806 c 3.887,-2.71488 5.31639,1.47608 5.3748,-0.61985 l 1.4237,-51.00495 c 3.0141,-1.57252 6.02719,-2.22752 8.9101,-2.22752 5.2418,0 7.3232,1.83302 7.45449,6.55059 l 0.57981,47.16174 c 3.6356,-1.03422 6.91929,0.79411 6.9344,-0.35191 l 0.6478,-49.06134 c 2.883,-1.83461 7.188,-4.17109 10.202,-4.17109 5.2417,0 6.3099,2.625 6.4185,8.91407 l 0.7878,45.61008 c 2.4651,-0.38781 5.9664,1.24342 5.99869,-0.39591 l 0.90381,-45.99801 c 0.2319,-11.79168 1.3508,-17.5642 -11.75331,-17.5642 -5.37279,0 -11.66119,1.57328 -16.1166,4.06311 -2.48989,-2.62065 -6.15859,-4.06311 -11.79349,-4.06311 -1.53611,0 -2.92451,-0.0721 -4.24301,-0.15595 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:64px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Andale Mono';writing-mode:lr-tb;display:inline;fill:#a00000;fill-opacity:1;stroke:#a00000;stroke-width:2.04755735;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#e19c9c;stroke-width:10.23778343;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3981-0-4-1-2-1"
+         d="m 543.04231,151.12743 -9.22811,-15.87595 -9.22809,-15.87613 h 18.4562 18.4561 l -9.2281,15.87613 z" />
+      <path
+         inkscape:connector-curvature="0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:10.28292942;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3983-4-9-2-9-2"
+         d="M 591.87701,197.91673 V 141.15132" />
+      <path
+         inkscape:connector-curvature="0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:10.23778343;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3985-4-0-9-3-9"
+         d="M 567.35701,197.89283 V 157.30716" />
+      <path
+         inkscape:connector-curvature="0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:9.56036377;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3951-0-4-91-2-1-3"
+         d="m 543.04091,198.24848 -0.022,-24.06433" />
+      <g
+         id="text4707-9-1"
+         style="font-style:normal;font-weight:bold;font-size:131.04367065px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;fill:#3566a5;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         aria-label="2019"
+         transform="translate(-543.64573,65.472005)">
+        <path
+           id="path402"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;text-anchor:end;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1497.8502,77.970167 c 4.4555,-2.358786 12.9734,-3.93131 17.1667,-3.93131 4.7176,0 7.7316,2.48983 7.7316,6.945315 0,10.876624 -14.8079,22.670558 -25.8156,41.933978 -2.8829,5.1107 -3.4071,6.94531 -3.4071,11.66288 0,0.39313 0,2.48983 0.5242,4.06236 h 43.2444 c 3.2761,0 3.4071,-3.01401 3.4071,-15.20107 0,0 -7.0764,1.44148 -17.953,1.44148 h -9.6972 c 12.056,-19.52551 26.6019,-30.664218 26.6019,-46.389458 0,-11.924974 -5.2418,-18.477158 -20.0497,-18.477158 -11.794,0 -23.5879,3.276092 -23.5879,7.338446 0,2.227742 0.1311,6.945315 1.8346,10.745581 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path404"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;text-anchor:end;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1545.9944,99.85446 c 0,24.8983 4.0624,39.96832 23.1948,39.96832 18.8703,0 23.981,-14.93898 23.981,-44.816935 0,-22.932643 -6.9453,-34.988661 -23.7189,-34.988661 -16.5115,0 -23.4569,13.628542 -23.4569,39.837276 z m 15.9874,0.52418 c 0,-16.773595 1.1794,-27.519176 8.2557,-27.519176 6.028,0 7.4695,8.124708 7.4695,22.146381 0,23.587865 -2.6209,31.712565 -7.9937,31.712565 -6.8142,0 -7.7315,-6.55218 -7.7315,-26.33977 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path406"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;text-anchor:end;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1603.7048,76.528687 c 0,0 5.6349,-1.310437 12.4492,-1.572524 l -1.1794,49.927637 c -12.1871,0 -16.6425,0.78626 -16.6425,4.06236 0,3.40713 0.131,6.42114 0.3931,9.69723 h 43.6375 c 3.2761,0 3.2761,-3.14505 3.2761,-14.28376 0,0 -3.9313,0.52417 -7.9936,0.52417 h -7.3385 l 1.5725,-64.080354 c -0.6552,-0.524174 -2.6208,-0.786262 -3.8002,-0.786262 -6.9453,0 -26.6019,4.455485 -26.6019,7.46949 0,3.538179 0.6552,6.290096 2.2277,9.042013 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path408"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;text-anchor:end;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1663.512,138.3813 c -3.2761,0 -6.6833,-0.65522 -9.3041,-1.44148 -0.7863,2.75192 -1.3105,7.2074 -1.3105,9.69723 0,4.32444 5.5039,5.63488 12.5802,5.63488 23.3258,0 32.2368,-16.77359 32.6299,-51.36912 -0.6552,-33.54718 -3.9313,-42.065019 -22.8016,-42.065019 -15.7253,0 -24.6362,9.697232 -24.6362,32.760918 0,16.773591 7.3384,26.863951 17.8219,26.863951 7.4695,0 11.6629,-2.22774 15.2011,-6.68323 -0.9173,14.41481 -4.8486,26.60187 -20.1807,26.60187 z m 9.5661,-33.41614 c -5.3727,0 -7.9936,-5.896962 -7.9936,-14.938975 0,-12.318105 4.4555,-18.21507 10.4835,-18.21507 6.6832,0 8.5178,6.159052 8.5178,26.339778 v 0.786262 c -3.5382,4.586525 -7.2074,6.028005 -11.0077,6.028005 z"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer6"
+     inkscape:label="subtitle"
+     style="display:none">
+    <g
+       style="display:inline"
+       id="g1750"
+       transform="matrix(19.592171,0,0,19.592171,-2611.4376,-2143.7586)">
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.16364908px;line-height:100%;font-family:Galette;-inkscape-font-specification:'Galette Bold';letter-spacing:0px;word-spacing:0px;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:0.02372737px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         x="189.20885"
+         y="159.63116"
+         id="text1124"><tspan
+           sodipodi:role="line"
+           x="189.20885"
+           y="159.63116"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#a00000;fill-opacity:1;stroke-width:0.02372737px"
+           id="tspan1128">Osmocom Conference 2018, 18-19 October 2018, Berl   n</tspan></text>
+      <g
+         transform="matrix(0.20459945,0,0,0.20459945,173.99435,134.11683)"
+         id="g27740">
+        <g
+           id="g28309">
+          <path
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:normal;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.98000004;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6.24451828;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             d="m 3820.6562,472.26172 c -40.3422,0 -73.1445,32.3975 -73.1445,72.32812 0,30.32091 18.9212,56.28015 45.6875,67.02735 l 1.8555,-5.95508 c -24.2644,-9.91834 -41.2988,-33.51066 -41.2988,-61.07227 0,-36.51604 29.8935,-66.08398 66.9003,-66.08398 37.0069,0 66.8985,29.56794 66.8985,66.08398 0,24.66524 -13.6587,46.14338 -33.918,57.50977 -2.3907,1.34129 -4.8745,2.53952 -7.4355,3.58594 l 1.8535,5.96875 c 2.9828,-1.19355 5.8704,-2.56971 8.6426,-4.125 22.1465,-12.42531 37.1035,-35.96788 37.1035,-62.93946 0,-39.93062 -32.8023,-72.32812 -73.1446,-72.32812 z m 7.5,137.99414 c -2.4618,0.2706 -4.962,0.41602 -7.5,0.41602 -2.5028,0 -4.9696,-0.14473 -7.4003,-0.40821 l -1.8633,6.05469 c 3.0363,0.3807 6.1241,0.59767 9.2636,0.59766 3.182,0 6.3161,-0.2044 9.3926,-0.59571 z"
+             id="path3544-2"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ssccsssscccsscsccccc"
+             transform="matrix(0.04785074,0,0,0.04785074,-118.05951,92.995687)" />
+          <path
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a00000;stroke-width:6.34386444px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 3811.3887,563.87891 -30.2735,97.13867 h 78.9297 l -30.1523,-97.125 c -2.8017,1.31925 -5.9315,2.05859 -9.2364,2.05859 -3.3169,0 -6.4581,-0.74396 -9.2675,-2.07226 z m 9.2675,11.66406 19.3165,61.84961 h -38.4082 z"
+             transform="matrix(0.04785074,0,0,0.04785074,-118.05951,92.995687)"
+             id="path3548-6"
+             inkscape:connector-curvature="0" />
+          <path
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#a00000;stroke-width:0.3038334;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path3556-1"
+             d="m 65.796938,119.04618 c 0,0.56924 -0.463484,1.03071 -1.035215,1.03071 -0.571734,0 -1.035215,-0.46147 -1.035215,-1.03071 0,-0.56925 0.463481,-1.03071 1.035215,-1.03071 0.571731,0 1.035215,0.46146 1.035215,1.03071 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <path
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#3465a4;stroke-width:0.29880485;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+           id="path3552-8"
+           d="m 66.957088,119.05451 c 0,1.21246 -0.982899,2.19537 -2.195365,2.19537 -1.212466,0 -2.195365,-0.98291 -2.195365,-2.19537 0,-1.21246 0.982899,-2.19537 2.195365,-2.19537 1.212466,0 2.195365,0.98291 2.195365,2.19537 z"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer9"
+     inkscape:label="cc"
+     style="display:none">
+    <g
+       id="cclogo"
+       inkscape:label="Layer 1"
+       transform="matrix(1.4786532,0,0,1.4786532,811.28081,506.04527)"
+       style="stroke-width:0.63402295">
+      <g
+         inkscape:export-ydpi="300.23013"
+         inkscape:export-xdpi="300.23013"
+         inkscape:export-filename="/mnt/hgfs/Bov/Documents/Work/2007/cc/identity/srr buttons/big/by.png"
+         id="g260"
+         transform="matrix(0.9937728,0,0,0.9936696,-177.69267,6.25128e-7)"
+         style="stroke-width:0.63402295">
+        <path
+           style="fill:#aab2ab;stroke-width:0.63402295"
+           d="m 181.96579,0.51074 114.06396,0.20264 c 1.59375,0 3.01758,-0.23633 3.01758,3.18066 l -0.13965,37.56689 H 179.08737 V 3.75439 c 0,-1.68505 0.16309,-3.24365 2.87842,-3.24365 z"
+           nodetypes="ccccccc"
+           id="path3817_1_"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path263"
+           d="m 297.29636,0 h -116.229 c -1.24658,0 -2.26123,1.01416 -2.26123,2.26074 v 39.49658 c 0,0.28174 0.229,0.51025 0.51074,0.51025 h 119.73047 c 0.28174,0 0.51074,-0.22852 0.51074,-0.51025 V 2.26074 C 299.55807,1.01416 298.54343,0 297.29636,0 Z M 181.06735,1.02148 h 116.229 c 0.68408,0 1.24023,0.55566 1.24023,1.23926 0,0 0,15.94824 0,27.44971 h -83.34424 c -3.04492,5.50586 -8.91113,9.24414 -15.64355,9.24414 -6.73535,0 -12.6001,-3.73486 -15.64355,-9.24414 h -4.07764 c 0,-11.50146 0,-27.44971 0,-27.44971 1e-5,-0.68359 0.55616,-1.23926 1.23975,-1.23926 z"
+           inkscape:connector-curvature="0"
+           style="stroke-width:0.63402295" />
+        <g
+           id="g265"
+           enable-background="new    "
+           style="stroke-width:0.63402295">
+          <path
+             style="fill:#ffffff;stroke-width:0.63402295"
+             id="path267"
+             d="m 253.07761,32.95605 c 0.31738,0 0.60742,0.02832 0.87012,0.08398 0.26172,0.05566 0.48535,0.14746 0.67285,0.27539 0.18652,0.12695 0.33203,0.29688 0.43457,0.50781 0.10254,0.21191 0.1543,0.47266 0.1543,0.78418 0,0.33594 -0.0762,0.61523 -0.22949,0.83887 -0.15234,0.22461 -0.37891,0.40723 -0.67773,0.55078 0.41211,0.11816 0.71973,0.3252 0.92285,0.62109 0.20312,0.29589 0.30469,0.65234 0.30469,1.06934 0,0.33594 -0.0654,0.62695 -0.19629,0.87305 -0.13086,0.24512 -0.30762,0.44629 -0.52832,0.60156 -0.22168,0.15625 -0.47461,0.27148 -0.75781,0.3457 -0.28418,0.0752 -0.5752,0.1123 -0.875,0.1123 H 249.936 v -6.66406 h 3.14161 z m -0.1875,2.69532 c 0.26172,0 0.47656,-0.0625 0.64551,-0.18652 0.16797,-0.12402 0.25195,-0.3252 0.25195,-0.60449 0,-0.15527 -0.0283,-0.2832 -0.084,-0.38184 -0.0566,-0.09961 -0.13086,-0.17676 -0.22461,-0.2334 -0.0937,-0.05566 -0.20117,-0.09473 -0.32227,-0.11621 -0.1211,-0.02148 -0.24805,-0.03223 -0.37793,-0.03223 h -1.37402 v 1.55469 z m 0.0859,2.82812 c 0.14355,0 0.28027,-0.01367 0.41113,-0.04199 0.13086,-0.02832 0.24609,-0.0752 0.34668,-0.13965 0.0996,-0.06543 0.17871,-0.1543 0.23828,-0.2666 0.0596,-0.11133 0.0889,-0.25488 0.0889,-0.42871 0,-0.3418 -0.0967,-0.58594 -0.29004,-0.73242 -0.19336,-0.14551 -0.44922,-0.21875 -0.7666,-0.21875 h -1.59961 v 1.82812 z"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:#ffffff;stroke-width:0.63402295"
+             id="path269"
+             d="m 255.78854,32.95605 h 1.64355 l 1.56055,2.63184 1.55078,-2.63184 h 1.63379 l -2.47363,4.10645 v 2.55762 h -1.46875 v -2.59473 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(0.872921,0,0,0.872921,50.12536,143.2144)"
+           id="g5908_1_"
+           style="stroke-width:0.63402295">
+          <path
+             style="fill:#ffffff;stroke-width:0.63402295"
+             d="m 186.90065,-141.46002 c 0.006,8.68079 -7.02786,15.7215 -15.70808,15.72711 -8.68022,0.006 -15.72206,-7.02734 -15.7271,-15.70807 0,-0.006 0,-0.0123 0,-0.019 -0.005,-8.68079 7.02786,-15.7215 15.70808,-15.72656 8.68135,-0.006 15.72206,7.02734 15.7271,15.70813 0,0.006 0,0.0123 0,0.0184 z"
+             rx="22.939548"
+             type="arc"
+             cy="264.3577"
+             ry="22.939548"
+             cx="296.35416"
+             id="path5906_1_"
+             inkscape:connector-curvature="0" />
+          <g
+             transform="translate(-289.6157,99.0653)"
+             id="g5706_1_"
+             style="stroke-width:0.63402295">
+            <path
+               d="m 473.57574,-253.32751 c 3.48541,3.48541 5.22839,7.75391 5.22839,12.80219 0,5.04938 -1.71277,9.27203 -5.13831,12.66791 -3.63531,3.5766 -7.93182,5.36432 -12.88947,5.36432 -4.89777,0 -9.11987,-1.77319 -12.66513,-5.31952 -3.54581,-3.54584 -5.31845,-7.78302 -5.31845,-12.71271 0,-4.92859 1.77264,-9.19598 5.31845,-12.80219 3.4552,-3.48651 7.67728,-5.22949 12.66513,-5.22949 5.0483,-10e-6 9.31404,1.74297 12.79939,5.22949 z m -23.11798,2.34484 c -2.94672,2.97638 -4.41953,6.46289 -4.41953,10.46234 0,3.99835 1.45828,7.45526 4.37424,10.37067 2.9165,2.9165 6.38849,4.37421 10.41705,4.37421 4.02856,0 7.53015,-1.47223 10.50653,-4.4184 2.82593,-2.73645 4.23944,-6.17706 4.23944,-10.32648 0,-4.11804 -1.43646,-7.61346 -4.30768,-10.48468 -2.87067,-2.87067 -6.34991,-4.30658 -10.43829,-4.30658 -4.0884,1e-5 -7.54638,1.44318 -10.37176,4.32892 z m 7.75449,8.70319 c -0.45029,-0.98169 -1.1243,-1.47284 -2.02322,-1.47284 -1.58917,0 -2.38345,1.07007 -2.38345,3.20911 0,2.13953 0.79428,3.2085 2.38345,3.2085 1.04938,0 1.79892,-0.52075 2.24866,-1.56451 l 2.20276,1.17297 c -1.04993,1.86548 -2.62509,2.79846 -4.72549,2.79846 -1.6199,0 -2.91763,-0.4967 -3.89206,-1.48901 -0.9761,-0.99341 -1.46274,-2.36273 -1.46274,-4.10852 0,-1.71503 0.50229,-3.07654 1.50748,-4.08502 1.00519,-1.00854 2.25702,-1.51257 3.75781,-1.51257 2.22012,0 3.80981,0.87488 4.77081,2.62286 z m 10.36337,0 c -0.45087,-0.98169 -1.11145,-1.47284 -1.98242,-1.47284 -1.62103,0 -2.43213,1.07007 -2.43213,3.20911 0,2.13953 0.8111,3.2085 2.43213,3.2085 1.05109,0 1.78717,-0.52075 2.20728,-1.56451 l 2.25201,1.17297 c -1.04828,1.86548 -2.62122,2.79846 -4.71771,2.79846 -1.61768,0 -2.9126,-0.4967 -3.88647,-1.48901 -0.97217,-0.99341 -1.45935,-2.36273 -1.45935,-4.10852 0,-1.71503 0.49445,-3.07654 1.48285,-4.08502 0.98785,-1.00854 2.2453,-1.51257 3.7735,-1.51257 2.21619,0 3.80365,0.87488 4.76129,2.62286 z"
+               id="path5708_1_"
+               inkscape:connector-curvature="0"
+               style="stroke-width:0.63402295" />
+          </g>
+        </g>
+        <g
+           id="g275"
+           style="stroke-width:0.63402295">
+          <circle
+             style="fill:#ffffff;stroke-width:0.63402295"
+             id="circle277"
+             r="10.80664"
+             cy="15.31348"
+             cx="255.55124" />
+          <g
+             id="g279"
+             style="stroke-width:0.63402295">
+            <path
+               id="path281"
+               d="m 258.67819,12.18701 c 0,-0.4165 -0.33789,-0.75391 -0.75293,-0.75391 h -4.77344 c -0.41504,0 -0.75293,0.3374 -0.75293,0.75391 v 4.77295 h 1.33105 v 5.65186 h 3.61719 v -5.65186 h 1.33105 v -4.77295 z"
+               inkscape:connector-curvature="0"
+               style="stroke-width:0.63402295" />
+            <circle
+               id="circle283"
+               r="1.63281"
+               cy="9.1723604"
+               cx="255.53854"
+               style="stroke-width:0.63402295" />
+          </g>
+          <path
+             style="clip-rule:evenodd;fill-rule:evenodd;stroke-width:0.63402295"
+             id="path285"
+             d="m 255.5239,3.40723 c -3.23242,0 -5.96875,1.12793 -8.20801,3.38379 -2.29785,2.3335 -3.44629,5.0957 -3.44629,8.28467 0,3.18897 1.14844,5.93164 3.44629,8.22656 2.29785,2.29443 5.03418,3.44189 8.20801,3.44189 3.21289,0 5.99805,-1.15625 8.35352,-3.47119 2.21973,-2.19727 3.33008,-4.92969 3.33008,-8.19727 0,-3.26758 -1.12988,-6.02881 -3.3877,-8.28467 -2.25977,-2.25585 -5.02442,-3.38378 -8.2959,-3.38378 z m 0.0293,2.09961 c 2.64844,0 4.89746,0.93408 6.74707,2.80127 1.86914,1.84717 2.80371,4.10303 2.80371,6.76758 0,2.68359 -0.91504,4.91064 -2.74512,6.68018 -1.92871,1.90625 -4.19629,2.85889 -6.80566,2.85889 -2.61035,0 -4.85938,-0.94287 -6.74707,-2.82959 -1.88965,-1.88672 -2.83301,-4.12305 -2.83301,-6.70947 0,-2.58691 0.9541,-4.84229 2.8623,-6.76758 1.83009,-1.8672 4.06934,-2.80128 6.71778,-2.80128 z"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/osmodevcon2019/artwork/pause.svg
+++ b/osmodevcon2019/artwork/pause.svg
@@ -1,0 +1,1208 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1920"
+   height="1080"
+   viewBox="0 0 1800 1012.5"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"
+   sodipodi:docname="pause.svg"
+   inkscape:export-filename="pause.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3374-5-7-7-0">
+      <stop
+         id="stop3376-8-6-4-2"
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3378-6-7-4-9"
+         style="stop-color:#729fcf;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3362-8-6-0-9">
+      <stop
+         id="stop3364-4-5-78-9"
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3366-7-6-6-4"
+         style="stop-color:#3465a4;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.837126"
+       y1="44.528019"
+       x2="21.036427"
+       y2="21.041553"
+       id="linearGradient3991-3-88-5"
+       xlink:href="#linearGradient7101-4-9-4-1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient7101-4-9-4-1">
+      <stop
+         id="stop7103-0-4-31-0"
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7105-6-8-4-3"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="39.06765"
+       y1="28.5"
+       x2="39.421204"
+       y2="10.934953"
+       id="linearGradient3993-1-9-7"
+       xlink:href="#linearGradient6979-9-2-2-8"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient6979-9-2-2-8">
+      <stop
+         id="stop6981-9-9-0-8"
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6983-0-3-6-6"
+         style="stop-color:#555753;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <linearGradient
+       id="linearGradient7131-6-1-5-7">
+      <stop
+         id="stop7133-4-5-2-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7135-6-9-5-0"
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <linearGradient
+       id="linearGradient7153-0-1-9-75">
+      <stop
+         id="stop7155-8-7-3-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7157-5-7-7-7"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.837126"
+       y1="44.528019"
+       x2="21.036427"
+       y2="21.041553"
+       id="linearGradient3991-3-88-5-3"
+       xlink:href="#linearGradient7101-4-9-4-1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="39.06765"
+       y1="28.5"
+       x2="39.421204"
+       y2="10.934953"
+       id="linearGradient3993-1-9-7-2"
+       xlink:href="#linearGradient6979-9-2-2-8"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <linearGradient
+       x1="24.837126"
+       y1="44.528019"
+       x2="21.036427"
+       y2="21.041553"
+       id="linearGradient3991-3-88-5-3-4"
+       xlink:href="#linearGradient7101-4-9-4-1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="39.06765"
+       y1="28.5"
+       x2="39.421204"
+       y2="10.934953"
+       id="linearGradient3993-1-9-7-2-4"
+       xlink:href="#linearGradient6979-9-2-2-8"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-3"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-1"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-7"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-6"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-4"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-7"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-4"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-0"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9-2"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1-8"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2-9"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9-6"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       r="4.5250292"
+       fy="8.0709476"
+       fx="10.28125"
+       cy="8.0709476"
+       cx="10.28125"
+       gradientTransform="matrix(4.9499444,0,0,4.9510321,-11.38809,35.312197)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3637-3"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       inkscape:collect="always" />
+    <radialGradient
+       r="4.5250292"
+       fy="9.8424416"
+       fx="10.28125"
+       cy="9.8424416"
+       cx="10.28125"
+       gradientTransform="matrix(23.169932,0,0,7.6402677,-198.71238,8.843597)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3639-5"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       inkscape:collect="always" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9-9"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1-1"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2-2"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9-9"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9-9-7"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1-1-5"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2-2-9"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9-9-8"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9-9-7-7"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1-1-5-4"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2-2-9-5"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9-9-8-4"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9-20"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1-2"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2-3"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9-9-2"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <radialGradient
+       r="4.5250292"
+       fy="8.0709476"
+       fx="10.28125"
+       cy="8.0709476"
+       cx="10.28125"
+       gradientTransform="matrix(4.9499444,0,0,4.9510321,-11.38809,35.312197)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3637-3-3"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       inkscape:collect="always" />
+    <radialGradient
+       r="4.5250292"
+       fy="9.8424416"
+       fx="10.28125"
+       cy="9.8424416"
+       cx="10.28125"
+       gradientTransform="matrix(23.169932,0,0,7.6402677,-198.71238,8.843597)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3639-5-5"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       inkscape:collect="always" />
+    <radialGradient
+       cx="10.28125"
+       cy="7.8249326"
+       r="4.5250292"
+       fx="10.28125"
+       fy="7.8249326"
+       id="radialGradient3995-7-4-0-2-2-0-9-0"
+       xlink:href="#linearGradient3374-5-7-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2651111,0,0,2.2923498,16.215361,52.593597)" />
+    <radialGradient
+       cx="10.28125"
+       cy="9.8424416"
+       r="4.5250292"
+       fx="10.28125"
+       fy="9.8424416"
+       id="radialGradient3997-3-3-4-7-7-6-1-9"
+       xlink:href="#linearGradient3362-8-6-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.1803,0,0,5.0647752,-116.56897,28.614297)" />
+    <radialGradient
+       cx="8.9057236"
+       cy="1.7286602"
+       r="1.9952321"
+       fx="8.9057236"
+       fy="1.7286602"
+       id="radialGradient3999-1-4-6-0-0-3-2-36"
+       xlink:href="#linearGradient7131-6-1-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7375073,0,0,0.7201806,2.4345312,0.6617371)" />
+    <radialGradient
+       cx="8.3046875"
+       cy="1.1256332"
+       r="2.0507698"
+       fx="8.3046875"
+       fy="1.1256332"
+       id="radialGradient4001-9-6-9-6-60-6-9-2"
+       xlink:href="#linearGradient7153-0-1-9-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.2943491,0,0,5.2881329,-7.02204,58.291497)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7101-4-9-4-1"
+       id="linearGradient389"
+       gradientUnits="userSpaceOnUse"
+       x1="24.837126"
+       y1="44.528019"
+       x2="21.036427"
+       y2="21.041553" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6979-9-2-2-8"
+       id="linearGradient391"
+       gradientUnits="userSpaceOnUse"
+       x1="39.06765"
+       y1="28.5"
+       x2="39.421204"
+       y2="10.934953" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.49681617"
+     inkscape:cx="975.91768"
+     inkscape:cy="613.38069"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1080"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:measure-start="63.3968,-113.628"
+     inkscape:measure-end="34.3452,-129.3"
+     inkscape:snap-page="true"
+     inkscape:pagecheckerboard="true"
+     gridtolerance="5"
+     objecttolerance="10"
+     guidetolerance="10"
+     inkscape:lockguides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid20483" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     transform="translate(0,-67.5)"
+     sodipodi:insensitive="true">
+    <rect
+       style="opacity:1;fill:#fffff3;fill-opacity:1;stroke:none;stroke-width:1.00031257;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect20497"
+       width="1800"
+       height="1012.4999"
+       x="0"
+       y="67.5"
+       inkscape:label="bg color" />
+    <rect
+       style="display:inline;opacity:1;fill:#7ba4d9;fill-opacity:1;stroke:none;stroke-width:0.96588516;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect20265"
+       width="1800"
+       height="339.50528"
+       x="1.1368684e-13"
+       y="740.49463"
+       inkscape:label="Bande Blau Unten" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Text"
+     style="display:inline"
+     transform="translate(0,-67.5)">
+    <flowRoot
+       xml:space="preserve"
+       id="title"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;opacity:0;fill:#555555;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       transform="matrix(0.9375,0,0,0.9375,596.82417,403.33401)"
+       inkscape:label="title"
+       inkscape:transform-center-x="4.0178571"
+       inkscape:transform-center-y="-24.107143"><flowRegion
+         id="flowRegion20435"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1"><rect
+           id="rect20437"
+           width="604.28571"
+           height="189.99998"
+           x="61.42857"
+           y="67.714287"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1" /></flowRegion><flowPara
+         id="flowPara24792"
+         style="font-size:192px">Pause</flowPara></flowRoot>    <flowRoot
+       xml:space="preserve"
+       id="flowRoot25337"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"><flowRegion
+         id="flowRegion25339"><rect
+           id="rect25341"
+           width="14.285714"
+           height="90"
+           x="902.85712"
+           y="472.85715" /></flowRegion><flowPara
+         id="flowPara25343" /></flowRoot>    <flowRoot
+       inkscape:transform-center-y="-24.107143"
+       inkscape:transform-center-x="4.0178571"
+       inkscape:label="title"
+       transform="matrix(0.9375,0,0,0.9375,604.85988,449.04839)"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;opacity:0;fill:#555555;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="flowRoot1019"
+       xml:space="preserve"><flowRegion
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1"
+         id="flowRegion25395"><rect
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;font-family:'Trebuchet MS';-inkscape-font-specification:'Trebuchet MS, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1"
+           y="67.714287"
+           x="61.42857"
+           height="189.99998"
+           width="604.28571"
+           id="rect25393" /></flowRegion><flowPara
+         style="font-size:192px"
+         id="flowPara25397">Pause</flowPara></flowRoot>    <g
+       transform="translate(-5e-5,67.500004)"
+       aria-label="Pause"
+       style="font-style:normal;font-weight:normal;font-size:131.04367065px;line-height:125%;font-family:Sans;letter-spacing:0.28665793px;word-spacing:0px;display:inline;fill:#3566a5;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+       id="pause">
+      <path
+         d="m 786.1067,516.71667 c 10.61453,0 10.61453,0 10.61453,-2.09669 v -35.11971 h 4.58653 c 13.10437,0 24.11204,-6.94531 24.11204,-28.56752 0,-18.21507 -7.60054,-25.94664 -24.11204,-25.94664 h -12.97332 c -1.70357,0 -2.22774,0.65521 -2.22774,2.22774 z m 27.51917,-66.96331 c 0,14.54585 -3.80027,19.91864 -11.13872,19.91864 h -5.76592 v -35.38179 h 6.55219 c 7.73157,0 10.35245,6.15905 10.35245,15.46315 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:center;letter-spacing:0.28665793px;text-anchor:middle;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+         id="path1393"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 830.24794,457.0918 c 0,1.57253 0.26209,3.93131 1.44148,6.02801 3.80027,-1.57252 10.74558,-2.88296 17.29776,-2.88296 5.24175,0 8.12471,1.57253 8.12471,7.73158 v 10.35245 c -2.62087,-1.31044 -6.68323,-1.70357 -9.56619,-1.70357 -8.77992,0 -17.42881,3.27609 -17.42881,21.49116 0,17.95299 9.17306,20.04969 18.73925,19.91864 8.51784,0 14.67689,-2.35878 18.21507,-4.45548 0.65522,-9.95932 0.78626,-25.68456 0.78626,-40.75458 v -6.94532 c 0,-11.79393 -4.97966,-15.98733 -16.24941,-15.98733 -9.95932,0 -17.6909,2.0967 -19.91864,3.53818 -1.04835,0.78626 -1.44148,2.22774 -1.44148,3.66922 z m 26.86395,28.69857 c 0,7.07636 0,16.77359 -0.39313,21.09803 -1.17939,1.17939 -4.06235,2.22774 -6.94531,2.22774 -5.11071,0 -8.51784,-1.70357 -8.51784,-11.26975 0,-11.4008 4.45548,-13.23541 9.69723,-13.23541 1.83461,0 4.45548,0.39313 6.15905,1.17939 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:center;letter-spacing:0.28665793px;text-anchor:middle;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+         id="path1395"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 917.87725,451.19484 c -10.4835,0 -10.61454,0 -10.61454,2.22774 v 52.94164 c -2.75192,1.83462 -6.42114,2.35879 -8.77993,2.35879 -7.07635,0 -8.77992,-3.014 -8.77992,-11.53184 v -45.99633 c -11.00767,0 -11.00767,0 -11.00767,2.22774 v 42.85128 c 0,14.67689 4.06235,21.75325 19.65655,21.75325 7.07636,0 14.54585,-1.96565 19.52551,-4.71757 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:center;letter-spacing:0.28665793px;text-anchor:middle;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+         id="path1397"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 949.82733,449.8844 c -14.67689,0 -21.36011,6.2901 -21.36011,15.46316 0,4.32444 1.57252,9.04201 7.46949,13.89062 l 12.71123,10.87663 c 3.93131,3.53818 5.24175,6.68323 5.24175,10.22141 0,5.24174 -3.93131,8.1247 -10.61454,8.1247 -5.1107,0 -9.3041,-1.04835 -13.10437,-3.27609 -1.44148,2.35879 -1.83461,4.58653 -1.83461,6.15905 0,4.58653 6.68323,6.68323 15.98733,6.68323 13.36645,0 21.62221,-6.55218 21.62221,-18.21507 0,-6.55218 -2.0967,-10.87662 -7.73158,-16.38046 l -12.18706,-9.82827 c -4.45549,-3.66923 -5.24175,-5.76592 -5.24175,-8.12471 0,-4.06235 4.1934,-6.2901 10.35245,-6.2901 4.97966,0 8.91097,1.04835 12.84228,3.40714 1.44148,-1.57253 2.35879,-3.66922 2.35879,-5.37279 0,-2.62088 -3.01401,-7.33845 -16.51151,-7.33845 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:center;letter-spacing:0.28665793px;text-anchor:middle;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+         id="path1399"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 997.25081,449.8844 c -11.53184,0 -23.19473,4.71757 -23.19473,37.47849 0,25.55352 8.77993,30.66422 20.96699,30.66422 9.82823,0 18.08403,-3.14505 18.08403,-7.2074 0,-2.0967 -0.2621,-5.24175 -0.9173,-7.2074 -4.4555,2.48983 -9.6972,4.06235 -14.93899,4.06235 -7.99366,0 -11.66288,-3.66922 -12.18706,-17.55985 6.2901,0 18.34615,-0.39313 27.38815,-2.0967 1.0483,-4.71757 1.4415,-11.26975 1.4415,-17.03568 0,-14.15271 -5.6349,-21.09803 -16.64259,-21.09803 z m -1.17939,9.3041 c 5.63488,0 7.33848,3.53818 7.46948,12.97333 0,2.48983 -0.131,5.50383 -0.6552,7.86262 -4.58654,1.31043 -12.71125,1.57252 -17.6909,1.44148 0.78626,-17.6909 5.50383,-22.27743 10.87662,-22.27743 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:center;letter-spacing:0.28665793px;text-anchor:middle;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+         id="path1401"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="g425"
+       transform="translate(-88.796317,20.757175)">
+      <g
+         transform="matrix(2.0475567,0,0,2.0475567,542.97967,147.44228)"
+         id="g3732-6-8"
+         style="display:inline">
+        <path
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;opacity:0.8;fill:url(#radialGradient3637-3-3);fill-opacity:1;stroke:url(#radialGradient3639-5-5);stroke-width:1.46151388;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+           id="path3544-1-7"
+           d="m 60.69548,67.493897 c 0,11.5675 -9.48796,20.9448 -21.19195,20.9448 -11.703989,0 -21.191949,-9.3773 -21.191949,-20.9448 0,-11.5674 9.48796,-20.9447 21.191949,-20.9447 11.70399,0 21.19195,9.3773 21.19195,20.9447 z"
+           inkscape:connector-curvature="0" />
+        <g
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:#000000;fill-opacity:1;stroke:none"
+           id="g3546-8-9"
+           transform="matrix(1.4615138,0,0,2.5218672,4.4272,31.547917)">
+          <path
+             style="fill:url(#linearGradient389);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient391);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             id="path3548-79-2"
+             d="m 24,13 -8.1875,15.225744 c 11.445471,0 5.976697,0 16.34375,0 z m 0,4.96875 4,7.421875 h -7.953125 z"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:none;stroke:#ffffff;stroke-width:1.31358945px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+             id="path3550-2-0"
+             transform="matrix(1,0,0,0.57953638,4,2.7937247)"
+             d="M 26.355979,42.522608 20,21.277828 13.644021,42.522609"
+             inkscape:connector-curvature="0" />
+        </g>
+        <path
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:url(#radialGradient3995-7-4-0-2-2-0-9-0);fill-opacity:1;stroke:url(#radialGradient3997-3-3-4-7-7-6-1-9);stroke-width:1.46151388;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+           id="path3552-0-2"
+           d="m 53.38791,67.493897 c 0,7.6681 -6.21625,13.8844 -13.88438,13.8844 -7.66813,0 -13.884379,-6.2163 -13.884379,-13.8844 0,-7.6681 6.216249,-13.8844 13.884379,-13.8844 7.66813,0 13.88438,6.2163 13.88438,13.8844 z"
+           inkscape:connector-curvature="0" />
+        <g
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:#000000;fill-opacity:1;stroke:none"
+           id="g3554-2-3"
+           transform="matrix(3.2735609,0,0,3.2593101,-24.33091,59.292917)">
+          <path
+             style="fill:url(#radialGradient3999-1-4-6-0-0-3-2-36);fill-opacity:1;stroke:#555753;stroke-width:0.39671427;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+             id="path3556-3-7"
+             transform="matrix(1.1130433,0,0,1.1428572,9.2565233,-0.07142864)"
+             d="M 11,2.25 C 11,3.2164983 10.195512,4 9.203125,4 8.2107383,4 7.40625,3.2164983 7.40625,2.25 7.40625,1.2835017 8.2107383,0.5 9.203125,0.5 10.195512,0.5 11,1.2835017 11,2.25 Z"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:#ffffff;fill-opacity:1;stroke:none"
+             id="path3558-7-5"
+             transform="matrix(1.8125,0,0,1.8125,-16.465404,-0.9288198)"
+             d="M 20,1.5 C 20,1.7761424 19.776142,2 19.5,2 19.223858,2 19,1.7761424 19,1.5 19,1.2238576 19.223858,1 19.5,1 19.776142,1 20,1.2238576 20,1.5 Z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <path
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:url(#radialGradient4001-9-6-9-6-60-6-9-2);stroke-width:1.46151364;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+           id="path3560-5-9"
+           d="m 44.61882,67.441097 c 0,2.8124 -2.2902,5.0924 -5.1153,5.0924 -2.8251,0 -5.1153,-2.28 -5.1153,-5.0924 0,-2.8125 2.2902,-5.0924 5.1153,-5.0924 2.8251,0 5.1153,2.2799 5.1153,5.0924 z"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="text3743-6-9-2"
+         style="font-style:normal;font-weight:normal;font-size:131.04367065px;line-height:125%;font-family:Sans;letter-spacing:0.28665793px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         aria-label="Os"
+         transform="translate(-299.49227,219.11692)">
+        <path
+           id="path381"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';letter-spacing:0.28665793px;fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 972.19144,89.895193 c 0,37.740577 6.68323,47.568857 23.58786,47.568857 17.2978,0 24.7673,-11.92498 24.7673,-47.961988 0,-35.381791 -6.2901,-46.127372 -23.32582,-46.127372 -16.90463,0 -25.02934,11.662887 -25.02934,46.520503 z m 11.92498,2.620874 c 0,-28.305433 3.66922,-38.264752 12.84228,-38.264752 9.4351,0 12.056,9.3041 12.056,35.512835 0,26.73291 -3.2761,36.82327 -12.71122,36.82327 -9.3041,0 -12.18706,-9.69723 -12.18706,-34.071353 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path383"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';letter-spacing:0.28665793px;fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1050.0211,69.452381 c -14.6768,0 -21.3601,6.290096 -21.3601,15.463153 0,4.324441 1.5726,9.042013 7.4695,13.890629 l 12.7113,10.876627 c 3.9313,3.53818 5.2417,6.68322 5.2417,10.2214 0,5.24175 -3.9313,8.12471 -10.6145,8.12471 -5.1107,0 -9.3041,-1.04835 -13.1044,-3.27609 -1.4415,2.35879 -1.8346,4.58653 -1.8346,6.15905 0,4.58653 6.6832,6.68323 15.9873,6.68323 13.3665,0 21.6222,-6.55218 21.6222,-18.21507 0,-6.55218 -2.0967,-10.87663 -7.7316,-16.38046 l -12.187,-9.828275 c -4.4555,-3.669223 -5.2418,-5.765921 -5.2418,-8.124708 0,-4.062353 4.1934,-6.290096 10.3525,-6.290096 4.9796,0 8.911,1.04835 12.8423,3.407136 1.4414,-1.572524 2.3587,-3.669223 2.3587,-5.372791 0,-2.620873 -3.014,-7.338445 -16.5115,-7.338445 z"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="text3760-7-2-8"
+         style="font-style:normal;font-weight:normal;font-size:81.90226746px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         aria-label="o"
+         transform="translate(-299.49227,219.11692)">
+        <path
+           id="path386"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1154.9617,103.52374 c 0,29.48482 7.0764,34.07135 20.5739,34.07135 14.0216,0 21.4911,-10.09036 21.4911,-34.46449 0,-26.601861 -6.5522,-33.678219 -20.3118,-33.678219 -13.7595,0 -21.7532,10.090362 -21.7532,34.071359 z m 11.5318,0.26208 c 0,-20.44281 4.0624,-25.029339 9.8283,-25.029339 6.1591,0 9.1731,3.669223 9.1731,24.505169 0,20.44281 -4.0624,25.29143 -9.6973,25.29143 -6.028,0 -9.3041,-3.14505 -9.3041,-24.76726 z"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="text4707-97-7"
+         style="font-style:normal;font-weight:bold;font-size:131.04367065px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Yanone Kaffeesatz Bold';letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         aria-label="DevCon"
+         transform="translate(-299.49227,219.11692)">
+        <path
+           id="path389"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1209.8369,45.864447 c -2.883,0 -3.6693,0.917306 -3.6693,2.620873 v 89.1097 h 16.9047 c 17.6909,0 25.0293,-15.46316 25.0293,-50.451817 0,-33.678223 -8.2557,-41.278756 -25.6845,-41.278756 z m 21.3601,39.706232 c 0,33.285091 -3.6692,38.133711 -7.7316,38.133711 h -2.6209 V 59.230901 h 2.4899 c 4.7175,0 7.8626,2.882961 7.8626,26.339778 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path391"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1276.5565,70.762744 c -12.3181,0 -23.0637,5.503835 -23.0637,37.216406 0,24.89829 8.3868,30.9263 20.3118,30.9263 10.2214,0 18.6082,-2.88296 18.6082,-8.1247 0,-3.01401 -0.3931,-7.20741 -1.1794,-9.82828 -4.5865,2.22774 -9.173,3.66922 -13.8906,3.66922 -6.2901,0 -8.1247,-3.66922 -8.5179,-11.92497 6.4212,-0.13104 16.2495,-0.65522 22.6706,-1.96566 1.3104,-5.1107 1.8346,-12.318101 1.8346,-18.608197 0,-15.201066 -6.2901,-21.360119 -16.7736,-21.360119 z m -1.9656,12.711236 c 3.2761,0 4.4554,1.310437 4.4554,9.697232 0,2.096699 -0.131,5.241747 -0.6552,6.814271 -1.9656,0.917307 -6.028,1.179397 -9.6972,1.179397 0.3931,-11.924978 1.8346,-17.6909 5.897,-17.6909 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path393"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1308.3612,131.69805 c 0.7863,3.66922 2.3588,6.55218 6.1591,6.55218 2.7519,0 7.6005,-0.13104 10.6145,-0.65521 l 13.1044,-65.521839 c -15.07,0 -15.07,0 -15.4632,2.882961 l -1.8346,15.987328 c -1.3104,11.26976 -2.4898,31.31944 -2.4898,31.31944 h -0.2621 c 0,0 -1.1794,-20.04968 -2.6209,-31.31944 l -2.3588,-18.870289 c -16.7735,0 -16.9046,0 -15.9873,4.324441 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path395"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1368.2584,43.898792 c -11.7939,0 -26.2087,7.86262 -26.2087,50.844944 0,36.692224 7.0764,44.816934 21.8843,44.816934 9.9593,0 15.9873,-3.53818 15.9873,-9.69723 0,-3.14505 -0.9173,-6.42114 -1.9656,-8.64888 -2.4899,1.31043 -6.1591,1.96565 -10.2214,1.96565 -7.3385,0 -10.2215,-6.81427 -10.2215,-29.615867 0,-28.56752 6.8143,-35.381791 14.2838,-35.381791 2.883,0 5.2418,1.048349 6.8143,2.227742 1.0483,-2.227742 2.0967,-5.241746 2.0967,-8.779925 0,-3.931311 -1.3105,-7.731577 -12.4492,-7.731577 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path397"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1382.3395,104.70306 c 0,29.35378 6.5522,34.20239 20.7049,34.20239 14.1527,0 21.4911,-9.43514 21.4911,-34.72657 0,-26.470821 -6.4211,-33.416136 -20.4428,-33.416136 -13.8906,0 -21.7532,10.221407 -21.7532,33.940316 z m 16.1184,-0.13105 c 0,-18.6082 2.2277,-21.229073 5.1107,-21.229073 3.8002,0 4.8486,2.358786 4.8486,21.229073 0,20.18073 -2.4899,22.14638 -4.9797,22.14638 -3.2761,0 -4.9796,-1.70357 -4.9796,-22.14638 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path399"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1430.7683,137.59502 c 14.4148,0 14.6769,0 14.6769,-2.62088 V 84.915461 c 1.4415,-1.048349 3.2761,-1.572524 4.9797,-1.572524 3.6692,0 4.3244,2.096699 4.3244,8.910969 v 45.341114 c 14.8079,0 15.2011,0 15.2011,-2.62088 V 87.667378 c 0,-13.104367 -5.6349,-16.904634 -18.8703,-16.904634 -6.5522,0 -16.2494,2.358787 -20.3118,4.324442 z"
+           inkscape:connector-curvature="0" />
+      </g>
+      <path
+         inkscape:connector-curvature="0"
+         id="path3959-9-26-3-1-6"
+         d="m 796.07086,289.49975 -8.87409,15.2727 -4.0593,-6.9865 1.2039,55.02807 c 3.887,-2.71488 5.31639,1.47608 5.3748,-0.61985 l 1.4237,-51.00496 c 3.0141,-1.57252 6.02719,-2.22752 8.9101,-2.22752 5.2418,0 7.3232,1.83302 7.45449,6.55059 l 0.57981,47.16175 c 3.6356,-1.03422 6.91929,0.79411 6.9344,-0.35191 l 0.6478,-49.06135 c 2.883,-1.83461 7.188,-4.17109 10.202,-4.17109 5.2417,0 6.3099,2.625 6.4185,8.91407 l 0.7878,45.61009 c 2.4651,-0.38781 5.9664,1.24342 5.99869,-0.39591 l 0.90381,-45.99802 c 0.2319,-11.79168 1.3508,-17.56419 -11.75331,-17.56419 -5.37279,0 -11.66119,1.57328 -16.1166,4.06311 -2.48989,-2.62065 -6.15859,-4.06311 -11.79349,-4.06311 -1.53611,0 -2.92451,-0.0721 -4.24301,-0.15595 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:64px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Andale Mono';writing-mode:lr-tb;display:inline;fill:#a00000;fill-opacity:1;stroke:#a00000;stroke-width:2.04755735;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#e19c9c;stroke-width:10.23778343;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3981-0-4-1-2-1"
+         d="m 787.19577,304.77234 -9.22811,-15.87594 -9.22809,-15.87614 h 18.4562 18.4561 l -9.2281,15.87614 z" />
+      <path
+         inkscape:connector-curvature="0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:10.28292942;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3983-4-9-2-9-2"
+         d="M 836.03047,351.56165 V 294.79623" />
+      <path
+         inkscape:connector-curvature="0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:10.23778343;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3985-4-0-9-3-9"
+         d="M 811.51047,351.53775 V 310.95207" />
+      <path
+         inkscape:connector-curvature="0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:9.56036377;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3951-0-4-91-2-1-3"
+         d="m 787.19437,351.8934 -0.022,-24.06434" />
+      <g
+         id="text4707-9-1"
+         style="font-style:normal;font-weight:bold;font-size:131.04367065px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;fill:#3566a5;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+         aria-label="2019"
+         transform="translate(-299.49227,219.11692)">
+        <path
+           id="path402"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;text-anchor:end;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1497.8502,77.970167 c 4.4555,-2.358786 12.9734,-3.93131 17.1667,-3.93131 4.7176,0 7.7316,2.48983 7.7316,6.945315 0,10.876624 -14.8079,22.670558 -25.8156,41.933978 -2.8829,5.1107 -3.4071,6.94531 -3.4071,11.66288 0,0.39313 0,2.48983 0.5242,4.06236 h 43.2444 c 3.2761,0 3.4071,-3.01401 3.4071,-15.20107 0,0 -7.0764,1.44148 -17.953,1.44148 h -9.6972 c 12.056,-19.52551 26.6019,-30.664218 26.6019,-46.389458 0,-11.924974 -5.2418,-18.477158 -20.0497,-18.477158 -11.794,0 -23.5879,3.276092 -23.5879,7.338446 0,2.227742 0.1311,6.945315 1.8346,10.745581 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path404"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;text-anchor:end;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1545.9944,99.85446 c 0,24.8983 4.0624,39.96832 23.1948,39.96832 18.8703,0 23.981,-14.93898 23.981,-44.816935 0,-22.932643 -6.9453,-34.988661 -23.7189,-34.988661 -16.5115,0 -23.4569,13.628542 -23.4569,39.837276 z m 15.9874,0.52418 c 0,-16.773595 1.1794,-27.519176 8.2557,-27.519176 6.028,0 7.4695,8.124708 7.4695,22.146381 0,23.587865 -2.6209,31.712565 -7.9937,31.712565 -6.8142,0 -7.7315,-6.55218 -7.7315,-26.33977 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path406"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;text-anchor:end;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1603.7048,76.528687 c 0,0 5.6349,-1.310437 12.4492,-1.572524 l -1.1794,49.927637 c -12.1871,0 -16.6425,0.78626 -16.6425,4.06236 0,3.40713 0.131,6.42114 0.3931,9.69723 h 43.6375 c 3.2761,0 3.2761,-3.14505 3.2761,-14.28376 0,0 -3.9313,0.52417 -7.9936,0.52417 h -7.3385 l 1.5725,-64.080354 c -0.6552,-0.524174 -2.6208,-0.786262 -3.8002,-0.786262 -6.9453,0 -26.6019,4.455485 -26.6019,7.46949 0,3.538179 0.6552,6.290096 2.2277,9.042013 z"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path408"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;text-anchor:end;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+           d="m 1663.512,138.3813 c -3.2761,0 -6.6833,-0.65522 -9.3041,-1.44148 -0.7863,2.75192 -1.3105,7.2074 -1.3105,9.69723 0,4.32444 5.5039,5.63488 12.5802,5.63488 23.3258,0 32.2368,-16.77359 32.6299,-51.36912 -0.6552,-33.54718 -3.9313,-42.065019 -22.8016,-42.065019 -15.7253,0 -24.6362,9.697232 -24.6362,32.760918 0,16.773591 7.3384,26.863951 17.8219,26.863951 7.4695,0 11.6629,-2.22774 15.2011,-6.68323 -0.9173,14.41481 -4.8486,26.60187 -20.1807,26.60187 z m 9.5661,-33.41614 c -5.3727,0 -7.9936,-5.896962 -7.9936,-14.938975 0,-12.318105 4.4555,-18.21507 10.4835,-18.21507 6.6832,0 8.5178,6.159052 8.5178,26.339778 v 0.786262 c -3.5382,4.586525 -7.2074,6.028005 -11.0077,6.028005 z"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="title"
+     style="display:none">
+    <g
+       style="display:inline"
+       id="g3732-6"
+       transform="matrix(2.0475567,0,0,2.0475567,979.07908,-71.674635)">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 60.69548,67.493897 c 0,11.5675 -9.48796,20.9448 -21.19195,20.9448 -11.703989,0 -21.191949,-9.3773 -21.191949,-20.9448 0,-11.5674 9.48796,-20.9447 21.191949,-20.9447 11.70399,0 21.19195,9.3773 21.19195,20.9447 z"
+         id="path3544-1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;opacity:0.8;fill:url(#radialGradient3637-3);fill-opacity:1;stroke:url(#radialGradient3639-5);stroke-width:1.46151388;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+      <g
+         transform="matrix(1.4615138,0,0,2.5218672,4.4272,31.547917)"
+         id="g3546-8"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:#000000;fill-opacity:1;stroke:none">
+        <path
+           inkscape:connector-curvature="0"
+           d="m 24,13 -8.1875,15.225744 c 11.445471,0 5.976697,0 16.34375,0 z m 0,4.96875 4,7.421875 h -7.953125 z"
+           id="path3548-79"
+           style="fill:url(#linearGradient3991-3-88-5);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3993-1-9-7);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 26.355979,42.522608 20,21.277828 13.644021,42.522609"
+           transform="matrix(1,0,0,0.57953638,4,2.7937247)"
+           id="path3550-2"
+           style="fill:none;stroke:#ffffff;stroke-width:1.31358945px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <path
+         inkscape:connector-curvature="0"
+         d="m 53.38791,67.493897 c 0,7.6681 -6.21625,13.8844 -13.88438,13.8844 -7.66813,0 -13.884379,-6.2163 -13.884379,-13.8844 0,-7.6681 6.216249,-13.8844 13.884379,-13.8844 7.66813,0 13.88438,6.2163 13.88438,13.8844 z"
+         id="path3552-0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:url(#radialGradient3995-7-4-0-2-2-0-9-9);fill-opacity:1;stroke:url(#radialGradient3997-3-3-4-7-7-6-1-1);stroke-width:1.46151388;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+      <g
+         transform="matrix(3.2735609,0,0,3.2593101,-24.33091,59.292917)"
+         id="g3554-2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:#000000;fill-opacity:1;stroke:none">
+        <path
+           inkscape:connector-curvature="0"
+           d="M 11,2.25 C 11,3.2164983 10.195512,4 9.203125,4 8.2107383,4 7.40625,3.2164983 7.40625,2.25 7.40625,1.2835017 8.2107383,0.5 9.203125,0.5 10.195512,0.5 11,1.2835017 11,2.25 Z"
+           transform="matrix(1.1130433,0,0,1.1428572,9.2565233,-0.07142864)"
+           id="path3556-3"
+           style="fill:url(#radialGradient3999-1-4-6-0-0-3-2-2);fill-opacity:1;stroke:#555753;stroke-width:0.39671427;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 20,1.5 C 20,1.7761424 19.776142,2 19.5,2 19.223858,2 19,1.7761424 19,1.5 19,1.2238576 19.223858,1 19.5,1 19.776142,1 20,1.2238576 20,1.5 Z"
+           transform="matrix(1.8125,0,0,1.8125,-16.465404,-0.9288198)"
+           id="path3558-7"
+           style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      </g>
+      <path
+         inkscape:connector-curvature="0"
+         d="m 44.61882,67.441097 c 0,2.8124 -2.2902,5.0924 -5.1153,5.0924 -2.8251,0 -5.1153,-2.28 -5.1153,-5.0924 0,-2.8125 2.2902,-5.0924 5.1153,-5.0924 2.8251,0 5.1153,2.2799 5.1153,5.0924 z"
+         id="path3560-5"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:url(#radialGradient4001-9-6-9-6-60-6-9-9);stroke-width:1.46151364;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:131.04367065px;line-height:125%;font-family:Sans;letter-spacing:0.28665793px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+       x="1104.8673"
+       y="136.28465"
+       id="text3743-6-9"><tspan
+         sodipodi:role="line"
+         id="tspan3745-0-2"
+         x="1104.8673"
+         y="136.28465"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';letter-spacing:0.28665793px;fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+         dx="0 0">Os</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:81.90226746px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+       x="1288.4237"
+       y="136.28465"
+       id="text3760-7-2"><tspan
+         sodipodi:role="line"
+         id="tspan3762-0-8"
+         x="1288.4237"
+         y="136.28465"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';fill:#a00000;fill-opacity:1;stroke-width:2.04755735">o</tspan></text>
+    <text
+       id="text4707-97"
+       y="137.59502"
+       x="1338.8434"
+       style="font-style:normal;font-weight:bold;font-size:131.04367065px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Yanone Kaffeesatz Bold';letter-spacing:0px;word-spacing:0px;display:inline;fill:#a00000;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';fill:#a00000;fill-opacity:1;stroke-width:2.04755735"
+         y="137.59502"
+         x="1338.8434"
+         id="tspan4705-36"
+         sodipodi:role="line">Con</tspan></text>
+    <path
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:64px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Andale Mono';writing-mode:lr-tb;display:inline;fill:#a00000;fill-opacity:1;stroke:#a00000;stroke-width:2.04755735;stroke-opacity:1"
+       d="m 1232.1703,70.382821 -8.8741,15.272701 -4.0593,-6.986499 1.2039,55.028077 c 3.887,-2.71488 5.3164,1.47606 5.3748,-0.61985 l 1.4237,-51.004967 c 3.0141,-1.57252 6.0272,-2.227521 8.9101,-2.227521 5.2418,0 7.3232,1.833021 7.4545,6.550591 l 0.5798,47.161757 c 3.6356,-1.03422 6.9193,0.79411 6.9344,-0.35191 l 0.6478,-49.061357 c 2.883,-1.834612 7.188,-4.171091 10.202,-4.171091 5.2417,0 6.3099,2.625001 6.4185,8.914071 l 0.7878,45.610097 c 2.4651,-0.38781 5.9664,1.2434 5.9987,-0.39591 l 0.9038,-45.998027 c 0.2319,-11.791682 1.3508,-17.564192 -11.7533,-17.564192 -5.3728,0 -11.6612,1.573279 -16.1166,4.06311 -2.4899,-2.62065 -6.1586,-4.06311 -11.7935,-4.06311 -1.5361,0 -2.9245,-0.0721 -4.243,-0.155951 z"
+       id="path3959-9-26-3-1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1223.2952,85.655413 -9.2281,-15.875943 -9.2281,-15.876132 h 18.4562 18.4561 l -9.2281,15.876132 z"
+       id="path3981-0-4-1-2"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;fill-opacity:1;stroke:#e19c9c;stroke-width:10.23778343;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 1272.1299,132.44473 V 75.679302"
+       id="path3983-4-9-2-9"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:10.28292942;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 1247.6099,132.42081 V 91.835143"
+       id="path3985-4-0-9-3"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:10.23778343;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1223.2938,132.77646 -0.022,-24.06433"
+       id="path3951-0-4-91-2-1"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';display:inline;fill:none;stroke:#e19c9c;stroke-width:9.56036377;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <text
+       id="text4707-9"
+       y="138.64339"
+       x="1700.7795"
+       style="font-style:normal;font-weight:bold;font-size:131.04367065px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;display:inline;fill:#3566a5;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz Bold';text-align:end;text-anchor:end;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735"
+         y="138.64339"
+         x="1700.7795"
+         id="tspan4705-3"
+         sodipodi:role="line">2018</tspan></text>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer6"
+     inkscape:label="subtitle"
+     style="display:none">
+    <text
+       id="text1124"
+       y="206.16611"
+       x="1699.4823"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:61.98275375px;line-height:100%;font-family:Galette;-inkscape-font-specification:'Galette Bold';letter-spacing:0px;word-spacing:0px;display:inline;fill:#3465a4;fill-opacity:1;stroke:none;stroke-width:0.46487072px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         id="tspan1128"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:end;letter-spacing:0px;text-anchor:end;fill:#3465a4;fill-opacity:1;stroke-width:0.46487072px"
+         y="206.16611"
+         x="1699.4823"
+         sodipodi:role="line">0x2B || <tspan
+   id="tspan1454"
+   style="letter-spacing:0px;fill:#a00000;fill-opacity:1;stroke-width:0.46487072px">!</tspan>0x2B</tspan></text>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer13"
+     inkscape:label="pause"
+     style="display:none">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:131.04367065px;line-height:125%;font-family:Sans;letter-spacing:0.28665793px;word-spacing:0px;display:inline;fill:#3566a5;fill-opacity:1;stroke:none;stroke-width:2.04755735"
+       x="898.90765"
+       y="516.71667"
+       id="text3743-6-9-0"><tspan
+         sodipodi:role="line"
+         id="tspan3745-0-2-6"
+         x="899.05096"
+         y="516.71667"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.04367065px;font-family:'Yanone Kaffeesatz';-inkscape-font-specification:'Yanone Kaffeesatz';text-align:center;letter-spacing:0.28665793px;text-anchor:middle;fill:#3566a5;fill-opacity:1;stroke-width:2.04755735">Pause</tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
warning: the generated .ts (with the --debug option) are incorrect
because the not all animations have the same number of frames
while the rendered does not remove the frames generated from the
previous rendering before assembling all individual frames into a
.ts animation.
this bug will remain if the .frames cache folder is not cleared
before using ./make.py (also without --debug)